### PR TITLE
MILAB-1153: provide custom message to PlAgOverlayLoading

### DIFF
--- a/.changeset/gentle-buses-travel.md
+++ b/.changeset/gentle-buses-travel.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-shm-trees.ui': patch
+---
+
+Custom message for empty table

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -99,7 +99,7 @@ const gridOptions: GridOptions<TreeResult> = {
 
     <div :style="{ flex: 1 }">
       <AgGridVue :theme="AgGridTheme" :style="{ height: '100%' }" :rowData="result" :defaultColDef="defaultColDef"
-        :columnDefs="columnDefs" :grid-options="gridOptions" :loadingOverlayComponentParams="{ notReady: true }"
+        :columnDefs="columnDefs" :grid-options="gridOptions" :loadingOverlayComponentParams="{ notReady: true, message: `Configure the settings and click 'Run' to see the data` }"
         :loadingOverlayComponent=PlAgOverlayLoading :noRowsOverlayComponent=PlAgOverlayNoRows />
     </div>
 

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -99,7 +99,8 @@ const gridOptions: GridOptions<TreeResult> = {
 
     <div :style="{ flex: 1 }">
       <AgGridVue :theme="AgGridTheme" :style="{ height: '100%' }" :rowData="result" :defaultColDef="defaultColDef"
-        :columnDefs="columnDefs" :grid-options="gridOptions" :loadingOverlayComponentParams="{ notReady: true, message: `Configure the settings and click 'Run' to see the data` }"
+        :columnDefs="columnDefs" :grid-options="gridOptions" :loadingOverlayComponentParams="{ notReady: true, message: `Configure the settings and click
+    'Run' to see the data` }"
         :loadingOverlayComponent=PlAgOverlayLoading :noRowsOverlayComponent=PlAgOverlayNoRows />
     </div>
 


### PR DESCRIPTION
MILAB-1153: provide 'message': "Configure the settings and click 'Run' to see the data" to PlAgOverlayLoading when MiXCR SHM trees table is empty.