### PR TITLE
Upgrade MiXCR to 4.7.0-303-develop

### DIFF
--- a/.changeset/upgrade-mixcr-303.md
+++ b/.changeset/upgrade-mixcr-303.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-shm-trees.workflow': patch
+---
+
+Upgrade MiXCR to 4.7.0-303-develop — fix serialization hang in findShmTrees on large datasets

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: 2.3.1-24-main
       version: 2.3.1-24-main
     '@platforma-open/milaboratories.software-mixcr':
-      specifier: 4.7.0-302-develop
-      version: 4.7.0-302-develop
+      specifier: 4.7.0-303-develop
+      version: 4.7.0-303-develop
     '@platforma-open/milaboratories.software-ptransform':
       specifier: ^1.6.6
       version: 1.6.6
@@ -246,7 +246,7 @@ importers:
         version: 2.3.1-24-main
       '@platforma-open/milaboratories.software-mixcr':
         specifier: 'catalog:'
-        version: 4.7.0-302-develop
+        version: 4.7.0-303-develop
       '@platforma-open/milaboratories.software-ptransform':
         specifier: 'catalog:'
         version: 1.6.6
@@ -1271,8 +1271,8 @@ packages:
   '@platforma-open/milaboratories.software-mitool@2.3.1-24-main':
     resolution: {integrity: sha512-2TxarvPNeL/+KMWQWoZJtBaNuz1sFDDaZvpLxrEc/hpDgDawLzVyqomCdlL9rBq7TZSC4SIirIEued61xQpJ4A==}
 
-  '@platforma-open/milaboratories.software-mixcr@4.7.0-302-develop':
-    resolution: {integrity: sha512-O595tiq0/Ap8NiO7jpdN+N6P5Szpr4cUptkmvNN4knPprncgxxAobUrm7YQ5KxKzzJJCvVocpRs2QbWAu0azYQ==}
+  '@platforma-open/milaboratories.software-mixcr@4.7.0-303-develop':
+    resolution: {integrity: sha512-yfBLRotOch/EDtKsxYEEOkIJS344yvCkYopid6sOVmq0JAXHoDIW4K9Ckuk9RzV+/Zuh2Bcn5imbHkGrn8hmrA==}
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.0':
     resolution: {integrity: sha512-tQw07omRWh7XFNyGDZz1VeiRxjzprvXWxhJI3git3Yf0GlgsCMmdxwSd1gpeORwFU9ggvLTGwdlAMN5KkfFwAw==}
@@ -7052,7 +7052,7 @@ snapshots:
 
   '@platforma-open/milaboratories.software-mitool@2.3.1-24-main': {}
 
-  '@platforma-open/milaboratories.software-mixcr@4.7.0-302-develop': {}
+  '@platforma-open/milaboratories.software-mixcr@4.7.0-303-develop': {}
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ catalog:
   '@platforma-sdk/workflow-tengo': ^5.5.9
 
   '@platforma-open/milaboratories.software-small-binaries': ^1.15.19
-  '@platforma-open/milaboratories.software-mixcr': 4.7.0-302-develop
+  '@platforma-open/milaboratories.software-mixcr': 4.7.0-303-develop
   '@platforma-open/milaboratories.software-mitool': 2.3.1-24-main
   '@platforma-open/milaboratories.software-ptransform': ^1.6.6
 


### PR DESCRIPTION
## Summary
- Upgrade MiXCR software dependency from 4.7.0-302-develop to 4.7.0-303-develop
- Fixes serialization hang in `findShmTrees` on large datasets (integer overflow in ByteArrayDataOutput + size-aware block splitting in PrimitivOBlocks)

## Test plan
- [ ] CI passes
- [ ] Verified on GSK CP-12076 dataset (8 samples, 30 CPUs, 256 GB RAM)