### PR TITLE
MILAB-6319: surface info message when donor has no eligible clonotype datasets

### DIFF
--- a/.changeset/milab-6319-info-message.md
+++ b/.changeset/milab-6319-info-message.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.mixcr-shm-trees.model': patch
+'@platforma-open/milaboratories.mixcr-shm-trees.ui': patch
+---
+
+MILAB-6319: surface a model-side info message when the selected donor column has no eligible clonotype datasets, and keep the "Add dataset" dropdown visible. Previously the dropdown would disappear silently and the block could not be run; the user is now told why (e.g. clonotyping assembled with CDR3 only, or upstream still running).

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -271,10 +271,10 @@ export const model = BlockModel.create()
   })
 
   .output('infoMessage', (ctx) => {
-    // NOTE: while the result pool is still propagating clns p-columns (e.g. upstream
-    // MiXCR Clonotyping is still running), this output will briefly evaluate to the
-    // "no matching datasets" message before clearing once the eligible specs arrive.
-    // The user-facing message accounts for this — no extra UI gating is needed.
+    // NOTE: while the result pool is still propagating clns p-columns (e.g. an
+    // upstream clonotyping block is still running), this output will briefly
+    // evaluate to the empty-state message before clearing once eligible specs
+    // arrive. The user-facing message accounts for this — no extra UI gating needed.
     if (ctx.args.donorColumn === undefined) return undefined;
     if (ctx.args.datasetColumns.length > 0) return undefined;
 

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -276,18 +276,31 @@ export const model = BlockModel.create()
     // evaluate to the empty-state message before clearing once eligible specs
     // arrive. The user-facing message accounts for this — no extra UI gating needed.
     if (ctx.args.donorColumn === undefined) return undefined;
-    if (ctx.args.datasetColumns.length > 0) return undefined;
 
     const donorColumnSpec = ctx.resultPool.getSpecByRef(ctx.args.donorColumn);
     if (donorColumnSpec === undefined || !isPColumnSpec(donorColumnSpec)) return undefined;
 
     const sampleAxisId = getAxisId(donorColumnSpec.axesSpec[0]);
-    const hasAnyEligible = ctx.resultPool
-      .getSpecs()
-      .entries.filter(isPColumnSpecResult)
-      .some(({ obj: spec }) => isEligibleClnsSpec(spec, sampleAxisId));
 
-    if (hasAnyEligible) return undefined;
+    if (ctx.args.datasetColumns.length > 0) {
+      // Datasets are already selected. Suppress the message only when at least
+      // one selection is still eligible for the current donor. This catches the
+      // donor-switch case where the new donor's sample axis no longer matches
+      // the previously-selected clns columns.
+      const anySelectedEligible = ctx.args.datasetColumns.some((ref) => {
+        const spec = ctx.resultPool.getSpecByRef(ref);
+        return spec !== undefined && isPColumnSpec(spec) && isEligibleClnsSpec(spec, sampleAxisId);
+      });
+      if (anySelectedEligible) return undefined;
+    } else {
+      // No datasets selected yet. Suppress the message only when the result pool
+      // has at least one eligible clns p-column the user could pick.
+      const hasAnyEligible = ctx.resultPool
+        .getSpecs()
+        .entries.filter(isPColumnSpecResult)
+        .some(({ obj: spec }) => isEligibleClnsSpec(spec, sampleAxisId));
+      if (hasAnyEligible) return undefined;
+    }
 
     return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
       + 'The list refreshes after each clonotyping run.';

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,6 +1,7 @@
 import { GraphMakerState } from '@milaboratories/graph-maker';
 import {
   AxesSpec,
+  AxisId,
   BlockModel,
   InferOutputsType,
   NotNAPValue,
@@ -133,6 +134,17 @@ function treeNodesColumns(
 
 const InBasketPColumnName = 'pl7.app/dendrogram/inBasket';
 
+// Shared filter used by datasetOptions and infoMessage so they stay in lock-step.
+function isEligibleClnsSpec(spec: PColumnSpec, sampleAxisId: AxisId): boolean {
+  if (spec.name !== 'mixcr.com/clns') return false;
+  if (!matchAxesId([sampleAxisId], spec.axesSpec)) return false;
+  const af = spec.annotations?.['mixcr.com/assemblingFeature'];
+  if (af === undefined || af === 'CDR3' || af === '[CDR3]') return false;
+  const cfoe = spec.annotations?.['mixcr.com/coveredFeaturesOnExport'];
+  if (cfoe === undefined || cfoe === '') return false;
+  return true;
+}
+
 type BasketColumns = {
   allColumns: PColumn<PColumnValues>[];
   perBasket: Record<PlId, PColumn<PColumnValues>>;
@@ -245,18 +257,7 @@ export const model = BlockModel.create()
       ctx.resultPool
         .getSpecs()
         .entries.filter(isPColumnSpecResult)
-        .filter(
-          ({ obj: spec }) =>
-            spec.name === 'mixcr.com/clns' &&
-            matchAxesId([sampleAxisId], spec.axesSpec) &&
-            // Required: assemblingFeature must exist and not be CDR3 or [CDR3]
-            spec.annotations?.['mixcr.com/assemblingFeature'] !== undefined &&
-            spec.annotations?.['mixcr.com/assemblingFeature'] !== 'CDR3' &&
-            spec.annotations?.['mixcr.com/assemblingFeature'] !== '[CDR3]' &&
-            // Required: coveredFeaturesOnExport must exist (needed for export settings)
-            spec.annotations?.['mixcr.com/coveredFeaturesOnExport'] !== undefined &&
-            spec.annotations?.['mixcr.com/coveredFeaturesOnExport'] !== ''
-        ),
+        .filter(({ obj: spec }) => isEligibleClnsSpec(spec, sampleAxisId)),
       (v) => v.obj,
       { addLabelAsSuffix: true, includeNativeLabel: true }
     ).map(
@@ -267,6 +268,30 @@ export const model = BlockModel.create()
           assemblingFeature: spec.annotations!['mixcr.com/assemblingFeature']!
         } as DatasetOption)
     );
+  })
+
+  .output('infoMessage', (ctx) => {
+    // NOTE: while the result pool is still propagating clns p-columns (e.g. upstream
+    // MiXCR Clonotyping is still running), this output will briefly evaluate to the
+    // "no matching datasets" message before clearing once the eligible specs arrive.
+    // The user-facing message accounts for this — no extra UI gating is needed.
+    if (ctx.args.donorColumn === undefined) return undefined;
+    if (ctx.args.datasetColumns.length > 0) return undefined;
+
+    const donorColumnSpec = ctx.resultPool.getSpecByRef(ctx.args.donorColumn);
+    if (donorColumnSpec === undefined || !isPColumnSpec(donorColumnSpec)) return undefined;
+
+    const sampleAxisId = getAxisId(donorColumnSpec.axesSpec[0]);
+    const hasAnyEligible = ctx.resultPool
+      .getSpecs()
+      .entries.filter(isPColumnSpecResult)
+      .some(({ obj: spec }) => isEligibleClnsSpec(spec, sampleAxisId));
+
+    if (hasAnyEligible) return undefined;
+
+    return 'The selected donor column has no matching clonotype datasets. '
+      + 'SHM trees needs clonotypes assembled with a feature broader than CDR3 (e.g. VDJRegion). '
+      + 'If MiXCR Clonotyping is still running, the list will update when it completes.';
   })
 
   .output('treeNodes', (ctx) => {

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -290,7 +290,7 @@ export const model = BlockModel.create()
     if (hasAnyEligible) return undefined;
 
     return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
-      + 'The list updates each time an upstream clonotyping block finishes.';
+      + 'The list refreshes after each clonotyping run.';
   })
 
   .output('treeNodes', (ctx) => {

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -134,15 +134,13 @@ function treeNodesColumns(
 
 const InBasketPColumnName = 'pl7.app/dendrogram/inBasket';
 
-// Classification of why a mixcr.com/clns p-column might fail SHM trees' filter,
+// Classification of why a PColumnSpec might fail SHM trees' clns filter,
 // or 'eligible' if it passes. Used by datasetOptions (boolean eligibility) and
 // by infoMessage (cause-specific user messages).
-type ClnsClassification = 'eligible' | 'axes-mismatch' | 'cdr3-only' | 'missing-annotation';
+type ClnsClassification = 'eligible' | 'not-clns' | 'axes-mismatch' | 'cdr3-only' | 'missing-annotation';
 
 function classifyClnsSpec(spec: PColumnSpec, sampleAxisId: AxisId): ClnsClassification {
-  // Caller should pre-filter to name === 'mixcr.com/clns'; non-clns specs are
-  // categorised as missing-annotation to keep this total.
-  if (spec.name !== 'mixcr.com/clns') return 'missing-annotation';
+  if (spec.name !== 'mixcr.com/clns') return 'not-clns';
   if (!matchAxesId([sampleAxisId], spec.axesSpec)) return 'axes-mismatch';
   const af = spec.annotations?.['mixcr.com/assemblingFeature'];
   if (af === undefined) return 'missing-annotation';
@@ -325,15 +323,30 @@ export const model = BlockModel.create()
     const causes = new Set(classifications);
 
     if (causes.size === 1) {
-      if (causes.has('axes-mismatch'))
-        return 'Available clonotype data uses a different sample axis than this donor column. '
-          + 'Pick a donor column from the same dataset as your clonotyping.';
-      if (causes.has('cdr3-only'))
-        return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
-          + 'The list refreshes after each clonotyping run.';
-      if (causes.has('missing-annotation'))
-        return 'Available clonotype data lacks metadata SHM trees needs. '
-          + 'Re-run clonotyping with a current version.';
+      const [onlyCause] = [...causes];
+      switch (onlyCause) {
+        case 'axes-mismatch':
+          return 'Available clonotype data uses a different sample axis than this donor column. '
+            + 'Pick a donor column from the same dataset as your clonotyping.';
+        case 'cdr3-only':
+          return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
+            + 'The list refreshes after each clonotyping run.';
+        case 'missing-annotation':
+          return 'Available clonotype data lacks metadata SHM trees needs. '
+            + 'Re-run clonotyping with a current version.';
+        case 'eligible':
+        case 'not-clns':
+          // Unreachable in this branch: 'eligible' was excluded above, and clnsSpecs
+          // was already pre-filtered to spec.name === 'mixcr.com/clns'. Fall through
+          // to the mixed-causes fallback below.
+          break;
+        default: {
+          // Compile-time exhaustiveness guard: adding a new ClnsClassification
+          // variant must add a case here.
+          const _exhaustive: never = onlyCause;
+          void _exhaustive;
+        }
+      }
     }
 
     // Mixed causes — pool has clns that fail for different reasons. Fall back

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -261,6 +261,9 @@ export const model = BlockModel.create()
     const donorColumn = ctx.args.donorColumn;
     const donorColumnSpec = ctx.resultPool.getSpecByRef(donorColumn);
     if (donorColumnSpec === undefined || !isPColumnSpec(donorColumnSpec)) return undefined;
+    // donorOptions accepts pl7.app/metadata without enforcing axesSpec.length;
+    // guard against an axis-less metadata column so getAxisId() never sees undefined.
+    if (donorColumnSpec.axesSpec.length === 0) return undefined;
 
     const sampleAxisId = getAxisId(donorColumnSpec.axesSpec[0]);
 
@@ -290,6 +293,7 @@ export const model = BlockModel.create()
 
     const donorColumnSpec = ctx.resultPool.getSpecByRef(ctx.args.donorColumn);
     if (donorColumnSpec === undefined || !isPColumnSpec(donorColumnSpec)) return undefined;
+    if (donorColumnSpec.axesSpec.length === 0) return undefined;
 
     const sampleAxisId = getAxisId(donorColumnSpec.axesSpec[0]);
 
@@ -336,10 +340,11 @@ export const model = BlockModel.create()
             + 'Re-run clonotyping with a current version.';
         case 'eligible':
         case 'not-clns':
-          // Unreachable in this branch: 'eligible' was excluded above, and clnsSpecs
-          // was already pre-filtered to spec.name === 'mixcr.com/clns'. Fall through
-          // to the mixed-causes fallback below.
-          break;
+          // Defensively unreachable: 'eligible' was excluded above, and clnsSpecs
+          // was already pre-filtered to spec.name === 'mixcr.com/clns'. If either
+          // ever appears here, suppress the message rather than emit a misleading
+          // mixed-causes fallback.
+          return undefined;
         default: {
           // Compile-time exhaustiveness guard: adding a new ClnsClassification
           // variant must add a case here.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -134,15 +134,28 @@ function treeNodesColumns(
 
 const InBasketPColumnName = 'pl7.app/dendrogram/inBasket';
 
-// Shared filter used by datasetOptions and infoMessage so they stay in lock-step.
-function isEligibleClnsSpec(spec: PColumnSpec, sampleAxisId: AxisId): boolean {
-  if (spec.name !== 'mixcr.com/clns') return false;
-  if (!matchAxesId([sampleAxisId], spec.axesSpec)) return false;
+// Classification of why a mixcr.com/clns p-column might fail SHM trees' filter,
+// or 'eligible' if it passes. Used by datasetOptions (boolean eligibility) and
+// by infoMessage (cause-specific user messages).
+type ClnsClassification = 'eligible' | 'axes-mismatch' | 'cdr3-only' | 'missing-annotation';
+
+function classifyClnsSpec(spec: PColumnSpec, sampleAxisId: AxisId): ClnsClassification {
+  // Caller should pre-filter to name === 'mixcr.com/clns'; non-clns specs are
+  // categorised as missing-annotation to keep this total.
+  if (spec.name !== 'mixcr.com/clns') return 'missing-annotation';
+  if (!matchAxesId([sampleAxisId], spec.axesSpec)) return 'axes-mismatch';
   const af = spec.annotations?.['mixcr.com/assemblingFeature'];
-  if (af === undefined || af === 'CDR3' || af === '[CDR3]') return false;
+  if (af === undefined) return 'missing-annotation';
+  if (af === 'CDR3' || af === '[CDR3]') return 'cdr3-only';
   const cfoe = spec.annotations?.['mixcr.com/coveredFeaturesOnExport'];
-  if (cfoe === undefined || cfoe === '') return false;
-  return true;
+  if (cfoe === undefined || cfoe === '') return 'missing-annotation';
+  return 'eligible';
+}
+
+// Boolean wrapper around classifyClnsSpec for datasetOptions, which only cares
+// about the binary outcome.
+function isEligibleClnsSpec(spec: PColumnSpec, sampleAxisId: AxisId): boolean {
+  return classifyClnsSpec(spec, sampleAxisId) === 'eligible';
 }
 
 type BasketColumns = {
@@ -282,28 +295,52 @@ export const model = BlockModel.create()
 
     const sampleAxisId = getAxisId(donorColumnSpec.axesSpec[0]);
 
+    // Stale-selections case: dataset slots are filled, but none of the selected
+    // refs is still eligible under the current donor (e.g. donor was switched).
     if (ctx.args.datasetColumns.length > 0) {
-      // Datasets are already selected. Suppress the message only when at least
-      // one selection is still eligible for the current donor. This catches the
-      // donor-switch case where the new donor's sample axis no longer matches
-      // the previously-selected clns columns.
       const anySelectedEligible = ctx.args.datasetColumns.some((ref) => {
         const spec = ctx.resultPool.getSpecByRef(ref);
         return spec !== undefined && isPColumnSpec(spec) && isEligibleClnsSpec(spec, sampleAxisId);
       });
       if (anySelectedEligible) return undefined;
-    } else {
-      // No datasets selected yet. Suppress the message only when the result pool
-      // has at least one eligible clns p-column the user could pick.
-      const hasAnyEligible = ctx.resultPool
-        .getSpecs()
-        .entries.filter(isPColumnSpecResult)
-        .some(({ obj: spec }) => isEligibleClnsSpec(spec, sampleAxisId));
-      if (hasAnyEligible) return undefined;
+      return 'Selected datasets are incompatible with this donor column. '
+        + 'Clear them or switch back to the previous donor.';
     }
 
-    return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
-      + 'The list refreshes after each clonotyping run.';
+    // No datasets selected. Classify every clns spec in the pool so the message
+    // names the actual reason ineligibility, not just "CDR3".
+    const clnsSpecs = ctx.resultPool
+      .getSpecs()
+      .entries.filter(isPColumnSpecResult)
+      .map(({ obj: spec }) => spec)
+      .filter((spec) => spec.name === 'mixcr.com/clns');
+
+    if (clnsSpecs.length === 0) {
+      return 'No clonotype data yet. Add a clonotyping block upstream.';
+    }
+
+    const classifications = clnsSpecs.map((spec) => classifyClnsSpec(spec, sampleAxisId));
+    if (classifications.includes('eligible')) return undefined;
+
+    const causes = new Set(classifications);
+
+    if (causes.size === 1) {
+      if (causes.has('axes-mismatch'))
+        return 'Available clonotype data uses a different sample axis than this donor column. '
+          + 'Pick a donor column from the same dataset as your clonotyping.';
+      if (causes.has('cdr3-only'))
+        return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
+          + 'The list refreshes after each clonotyping run.';
+      if (causes.has('missing-annotation'))
+        return 'Available clonotype data lacks metadata SHM trees needs. '
+          + 'Re-run clonotyping with a current version.';
+    }
+
+    // Mixed causes — pool has clns that fail for different reasons. Fall back
+    // to a generic message that covers the dominant remediation paths.
+    return 'Available clonotype data is incompatible with this donor column. '
+      + 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion) '
+      + 'on a matching sample axis.';
   })
 
   .output('treeNodes', (ctx) => {

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -289,9 +289,8 @@ export const model = BlockModel.create()
 
     if (hasAnyEligible) return undefined;
 
-    return 'The selected donor column has no matching clonotype datasets. '
-      + 'SHM trees needs clonotypes assembled with a feature broader than CDR3 (e.g. VDJRegion). '
-      + 'If MiXCR Clonotyping is still running, the list will update when it completes.';
+    return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
+      + 'The list updates each time an upstream clonotyping block finishes.';
   })
 
   .output('treeNodes', (ctx) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.31.6
       version: 1.31.6
     '@platforma-sdk/tengo-builder':
-      specifier: ^2.3.3
-      version: 2.3.3
+      specifier: ^3.0.5
+      version: 3.0.5
     '@platforma-sdk/test':
       specifier: ^1.45.11
       version: 1.45.14
@@ -46,8 +46,8 @@ catalogs:
       specifier: 1.31.11
       version: 1.31.11
     '@platforma-sdk/workflow-tengo':
-      specifier: ^5.5.9
-      version: 5.5.11
+      specifier: ^5.26.0
+      version: 5.26.0
     '@vitejs/plugin-vue':
       specifier: ^5.2.4
       version: 5.2.4
@@ -239,7 +239,7 @@ importers:
     dependencies:
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.5.11
+        version: 5.26.0
     devDependencies:
       '@platforma-open/milaboratories.software-mitool':
         specifier: 'catalog:'
@@ -252,7 +252,7 @@ importers:
         version: 1.6.6
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.3.3
+        version: 3.0.5
       '@platforma-sdk/test':
         specifier: 'catalog:'
         version: 1.45.14(@types/node@24.5.2)
@@ -1150,6 +1150,9 @@ packages:
     resolution: {integrity: sha512-qr5lnaJSnI7PmZMh+/PJXOURe3jKSFLWiqo1Ha1OSbY0JwHOmpU8n2aZOGjwscLLTk8AgF6Jfv5t/kPhGk348g==}
     hasBin: true
 
+  '@milaboratories/pframes-rs-wasip2@1.1.35':
+    resolution: {integrity: sha512-kcR9YLWAbKYSpksPOoJWkcrkSiUUAEKj/Wuyc9aFsd2bNbWcIb7mLGptFOuvhLn07bZHn0oNcVgupEqd/6Ftbw==}
+
   '@milaboratories/pl-client@2.16.1':
     resolution: {integrity: sha512-XcFa5xBpQQ/jJwyEWXEwuX8yiqsUCmGSzaywvShcsJOOuSkX/u8gV5bIIgivV6X7nJt1yX+mukaugo4wjkZZoQ==}
     engines: {node: '>=22.19.0'}
@@ -1288,8 +1291,14 @@ packages:
   '@platforma-open/milaboratories.software-ptabler@1.13.3':
     resolution: {integrity: sha512-deswcfndJTUyHDgK7GofFn2n3XwtvuUfWS2fF6jZ0cwVkb2wht2FDaAKaIVu7bEDe3FopVC5PXa5D475FAKT7g==}
 
+  '@platforma-open/milaboratories.software-ptabler@1.16.1':
+    resolution: {integrity: sha512-m4tzKYlopjHLYpRLSjIqEtFr0QP7MuweaMCTEmr6a+gIVE+x9MKawdXwNwo1A/2QuatygIcGRvIcIz34WibZMA==}
+
   '@platforma-open/milaboratories.software-ptexter@1.2.0':
     resolution: {integrity: sha512-7dKhQyecDcxjRNOS9XRgLemZpOuJ3dKMryrBbbkYR6VLKj566tJkbKiC7p1wAWEtHKHEZUhCQYgTZfEtwHCkDA==}
+
+  '@platforma-open/milaboratories.software-ptexter@1.2.2':
+    resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
 
   '@platforma-open/milaboratories.software-ptransform@1.6.6':
     resolution: {integrity: sha512-J43RsEiEo98Hwb+ze1UO42gXa3VTDCqMdBLbkTZiEs5nOtnqetMKfFRcGcSn/uHlUAdkBLAQ6WmEtEIfAgaUcA==}
@@ -1297,17 +1306,26 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries.guided-command@1.1.1':
     resolution: {integrity: sha512-UPhSOP43GAL+gQVPlE/2ymjuOiYVojhmDad1moS4SI+t6IDF9QgnAj5I7V8eP2P2x0oSY5apgjg4EeUiGBrIkw==}
 
+  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10':
+    resolution: {integrity: sha512-16BGRLIrsVW+YIaXwWLX6Nbm80PS5mQJEclHhjNbRrRTLHPaKI4RygZfBC0lLNzvHBiTXU4Qkh1+WmdovkshDg==}
+
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.6':
     resolution: {integrity: sha512-eYRjtkKkRFidVvsp3QEGpAOAaba15W0T7VrvM8X0QgNsHtSn1OYp7+THMqZf06zWbvJ1IVfjturQXUtpuv6UjQ==}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.1':
     resolution: {integrity: sha512-XPf/+HeXgPMKJU/BdxxTMgV11LHyktm72Y2GWjqT2wa3ZYUeiwLuCvRHfgKIXtSC4qJnjDlgmdqQIzldnlWG6g==}
 
+  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7':
+    resolution: {integrity: sha512-CqXbfFld2l6Y/8rtcZXRPsa5kqNnaS3QWUxrcfMYwNxultbhLzjZGdqSR7ejV9xRWilXpeg6DdZJIKF3+KDH8g==}
+
   '@platforma-open/milaboratories.software-small-binaries.java-stub@1.0.4':
     resolution: {integrity: sha512-nr0H+TZDKUR7dpxY5Q5Gh1FOT9Jx4Sr0Uk6jO2I18jJaOPchEPY+gOxemPJO30SNkkkbQiIRBBJYF54tMFiesA==}
 
   '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.1':
     resolution: {integrity: sha512-4dJnBVFqxFgFznepUQAMJceWcJrGE2Ms5LH+2BMjG/qOFJpEAiWJlrjiobiapqf2jnJgxM1AcDVR9M67uGrySA==}
+
+  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5':
+    resolution: {integrity: sha512-ZdVg77pZ0Hgvxdk+mYahEyPbcTzDyz6Y7qlm6A0rJw8WCYmDVkfLqctQj0QkTLHM76oSWOHJIgD07ZxORjjgwA==}
 
   '@platforma-open/milaboratories.software-small-binaries.python-stub@1.0.4':
     resolution: {integrity: sha512-5HjuYrvxvYNLo2M7EkhoQFlwPk6VxV2aoRY8PDU9cf0qyDIrdY6g/q4zRslZ6wWFhw/hTGsZ8CLXPGvdqiuCHw==}
@@ -1330,8 +1348,14 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.1':
     resolution: {integrity: sha512-CFcYb/hbzQ1UiP4sMXnRUST+feUkQoRrc8/vXSaOfUZY0tKdEEJCas+huSZ04l2oUhMFAU2PSO8H91BSspfvQQ==}
 
+  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5':
+    resolution: {integrity: sha512-x6WOZ8S3uLXzmwliCF500hw7VQ4A9U3VBbESjJlPia26aU91FqB3ylKyH2fEyTiVw2wADlTYuui1tHX47iS5Lw==}
+
   '@platforma-open/milaboratories.software-small-binaries@1.15.23':
     resolution: {integrity: sha512-I1G2qEWALvNAJy9kOTXjryu0GvK+hvUCVPckNhGkFO/cGIsST7R7s9pm0exhG92PyuLFa5lwJFx/fgobqWUWNw==}
+
+  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
+    resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
 
   '@platforma-sdk/block-tools@2.6.16':
     resolution: {integrity: sha512-a5eo8UJ5dV3E3Ps4W9Vv7C/qkuu10oM1F1YUiSeRAOFwBnlsY3RpEfCckQBbPftX6yFs5U0ctGGdTvCuCtg3hQ==}
@@ -1367,8 +1391,8 @@ packages:
   '@platforma-sdk/model@1.45.0':
     resolution: {integrity: sha512-AMplDyyW/07D62/heNeh2yVd3Yx36Axq5qhxSIjFNvWnr3QVTxqLuch4OtyKZL1VB8ME6x+8vuNtPCFvrzQe8w==}
 
-  '@platforma-sdk/tengo-builder@2.3.3':
-    resolution: {integrity: sha512-Wdtnmswk1uv/x5gzGNTvDHPW0uvNP+vvjMwHHShUmR+ShGq8Jc+Ho/eAxFHIiGv9paed1kXZ/VZWzS3S+ma+RQ==}
+  '@platforma-sdk/tengo-builder@3.0.5':
+    resolution: {integrity: sha512-9RAd9nQrs3U5C0Ro43atN3n0pvNIbyDzJzoIF/UV569ic6NwowsxUBUgazgEczchH+4tVRMax32mGgWQGg/jIw==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -1377,6 +1401,9 @@ packages:
 
   '@platforma-sdk/ui-vue@1.31.11':
     resolution: {integrity: sha512-G69XU6lLQ7D+J9pDmQHRKZb64WQMrI9m/bod32AuCgqrKZkFdiy5w6qkHDZH/pW0UBprUerZzH6GclRc1Q+Ohg==}
+
+  '@platforma-sdk/workflow-tengo@5.26.0':
+    resolution: {integrity: sha512-lXoFzD0LsQqEF9WUkA48avAY7LOK9WdP7sIc/Bymu1fOm4peXEWWZFW7fYckCPhHEAwcyzjqh7jdE8pVXrfzvw==}
 
   '@platforma-sdk/workflow-tengo@5.5.11':
     resolution: {integrity: sha512-qLzmBICKEsOOGg1Hh/yrTKw6OnKP7BPr/Ee4u5kYVSg0+4E4NZq9WFzs3wSgOL/7g3szbKrd7MKNPebqlSPYaA==}
@@ -6779,6 +6806,8 @@ snapshots:
       commander: 14.0.1
       selfsigned: 3.0.1
 
+  '@milaboratories/pframes-rs-wasip2@1.1.35': {}
+
   '@milaboratories/pl-client@2.16.1':
     dependencies:
       '@grpc/grpc-js': 1.13.4
@@ -7091,19 +7120,29 @@ snapshots:
 
   '@platforma-open/milaboratories.software-ptabler@1.13.3': {}
 
+  '@platforma-open/milaboratories.software-ptabler@1.16.1': {}
+
   '@platforma-open/milaboratories.software-ptexter@1.2.0': {}
+
+  '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
   '@platforma-open/milaboratories.software-ptransform@1.6.6': {}
 
   '@platforma-open/milaboratories.software-small-binaries.guided-command@1.1.1': {}
 
+  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10': {}
+
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.6': {}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.1': {}
 
+  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7': {}
+
   '@platforma-open/milaboratories.software-small-binaries.java-stub@1.0.4': {}
 
   '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.1': {}
+
+  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5': {}
 
   '@platforma-open/milaboratories.software-small-binaries.python-stub@1.0.4': {}
 
@@ -7119,6 +7158,8 @@ snapshots:
 
   '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.1': {}
 
+  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5': {}
+
   '@platforma-open/milaboratories.software-small-binaries@1.15.23':
     dependencies:
       '@platforma-open/milaboratories.software-small-binaries.guided-command': 1.1.1
@@ -7133,6 +7174,13 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.sleep': 1.1.1
       '@platforma-open/milaboratories.software-small-binaries.small-asset': 1.1.4
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.1
+
+  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
+    dependencies:
+      '@platforma-open/milaboratories.software-small-binaries.hello-world': 1.1.7
+      '@platforma-open/milaboratories.software-small-binaries.hello-world-py': 1.0.10
+      '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
+      '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
   '@platforma-sdk/block-tools@2.6.16':
     dependencies:
@@ -7214,17 +7262,14 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@platforma-sdk/tengo-builder@2.3.3':
+  '@platforma-sdk/tengo-builder@3.0.5':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.1.18
-      '@milaboratories/resolve-helper': 1.1.1
+      '@milaboratories/pl-model-backend': 1.3.5
+      '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.5.1
+      '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.0.37
-      canonicalize: 2.1.0
       winston: 3.17.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@platforma-sdk/test@1.45.14(@types/node@24.5.2)':
     dependencies:
@@ -7271,6 +7316,14 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
       - typescript
+
+  '@platforma-sdk/workflow-tengo@5.26.0':
+    dependencies:
+      '@milaboratories/pframes-rs-wasip2': 1.1.35
+      '@milaboratories/software-pframes-conv': 2.2.9
+      '@platforma-open/milaboratories.software-ptabler': 1.16.1
+      '@platforma-open/milaboratories.software-ptexter': 1.2.2
+      '@platforma-open/milaboratories.software-small-binaries': 2.0.4
 
   '@platforma-sdk/workflow-tengo@5.5.11':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^1.6.6
       version: 1.6.6
     '@platforma-sdk/block-tools':
-      specifier: 2.6.48
-      version: 2.6.48
+      specifier: 2.9.2
+      version: 2.9.2
     '@platforma-sdk/blocks-deps-updater':
       specifier: ^2.0.0
       version: 2.0.0
@@ -131,7 +131,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.48
+        version: 2.9.2
 
   model:
     dependencies:
@@ -147,7 +147,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.48
+        version: 2.9.2
       tsup:
         specifier: 'catalog:'
         version: 8.3.5(postcss@8.5.3)(typescript@5.5.4)(yaml@2.8.1)
@@ -1126,6 +1126,10 @@ packages:
     resolution: {integrity: sha512-Eg3AQMJbVClYhdvhogdlW3Ys9EdLLl8ZTqG675iLwoO64ZJcQOAnIPjXwl4zJ/bZWx4nEhRF9AvwxRdc08fikQ==}
     engines: {node: '>=22'}
 
+  '@milaboratories/helpers@1.14.2':
+    resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
+    engines: {node: '>=22'}
+
   '@milaboratories/helpers@1.6.11':
     resolution: {integrity: sha512-TyERmUULB8hvbwqnMOQ14YAPQzVBGpBSLkByYpl3/5vCkf4OndBg+V8XqITHEZkca9y82LVm5IDU0hP7KOCQ9Q==}
     engines: {node: '>=20.10.0'}
@@ -1150,6 +1154,10 @@ packages:
     resolution: {integrity: sha512-XcFa5xBpQQ/jJwyEWXEwuX8yiqsUCmGSzaywvShcsJOOuSkX/u8gV5bIIgivV6X7nJt1yX+mukaugo4wjkZZoQ==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.9.2':
+    resolution: {integrity: sha512-Bv8TvriImpt8LKPL5qIolHULKjHZfn8rQHXS//0k5wOpgSR32V6UtVi4kmtkK3xsLcXodmtl1inP2fd1Pwdpig==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-config@1.7.6':
     resolution: {integrity: sha512-D3dSyCCW+9lVW6LTVpjcUU9pyr7qILo+mYDrv3YTYLLQuqreCmID+CSl1t9xj/fBZlxGvnY19f1yAnherMJJQw==}
 
@@ -1164,11 +1172,11 @@ packages:
   '@milaboratories/pl-error-like@1.12.1':
     resolution: {integrity: sha512-cFK6RJyTzX8JmEjyqTsnAJK48HZnKEmP/wVYAIV1iNFruanwdw377Gc8w8Ized2gDeMQT67yDDl9Qq/U4AO4gw==}
 
+  '@milaboratories/pl-error-like@1.12.10':
+    resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
+
   '@milaboratories/pl-error-like@1.12.5':
     resolution: {integrity: sha512-opYP4OrB6JBMsH9RMRmAH44+MG7PWiV08dHW9+RsXGOaqX+rYXs9TTBXYRhlVMDLwwefSKzelvDg8HL748aM+A==}
-
-  '@milaboratories/pl-error-like@1.12.8':
-    resolution: {integrity: sha512-j8evT0YYuXQndVcsk8bOGfH9qpXRefFiO7uCdptG9Lz0QTv4e6OOxNUJPe9+TSp/72PXUsCrYGHUeTqtvUb0lA==}
 
   '@milaboratories/pl-errors@1.1.33':
     resolution: {integrity: sha512-RKUdWQtpfiKz9TYS1/i6ZUP4azdjkJKMO3O7rbVWvAeZ9s89pp4G7Eq6fyDiSIuQA5G5HSfuPE54SuZbJVpEqw==}
@@ -1176,8 +1184,8 @@ packages:
   '@milaboratories/pl-http@1.2.0':
     resolution: {integrity: sha512-5iRxug4TjE88+XoMU5LVcXe1PEmXYfZI3WxJGrayzYQFM/9GiKuwcUsQ0kDlFmw+s6UlEAzgC9+MsJFKvU7C5Q==}
 
-  '@milaboratories/pl-http@1.2.3':
-    resolution: {integrity: sha512-39K69Tkws9EwU6lrSgd4txeN+vu/BcIyJIrLaX3Q9LKD+/LZCH39He5OayhA1YSJzso0WLI/FkGzW2OAOprA+A==}
+  '@milaboratories/pl-http@1.2.4':
+    resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
   '@milaboratories/pl-middle-layer@1.43.49':
     resolution: {integrity: sha512-Nnu+TqmIXiVGDSjtohbkEEJ2+Pqz7kA4LyK4Ci8lnxlXVTRr72VXSkf95911lp452S+s1H1qZ3UUXdFqSav3IQ==}
@@ -1185,6 +1193,9 @@ packages:
 
   '@milaboratories/pl-model-backend@1.1.18':
     resolution: {integrity: sha512-zYJPylAl281yWne8ysOGHn0MnO+zRk3B2rj8ZIkdvgxbhQmM8SgDnjisrS/BWGUAWMdvH/mxIfmQQQ/MAhMyPA==}
+
+  '@milaboratories/pl-model-backend@1.3.5':
+    resolution: {integrity: sha512-9SWpcZg98crSx6hArAncaEqlvo3AA+ZoA4mZsZSQ7P9tEOGSmQfMTo9WuNbudkCkiAuZm6Xsxv1sKTO4ojtx+g==}
 
   '@milaboratories/pl-model-common@1.15.3':
     resolution: {integrity: sha512-ZG7BZ88FXovX4JoXnXhxOuFyAXMD95SN65TE4rW/qC5NHwGLKGqdCb8qW7dF2UI1svtORZVPmIc9eO4bceDPhQ==}
@@ -1195,11 +1206,11 @@ packages:
   '@milaboratories/pl-model-common@1.21.4':
     resolution: {integrity: sha512-k0dqRSWF2npDXEI00F+on6g/B6LDIOlRTJTZ5Pc+vyj9n4GvlR2lT93GKJwJXEx4jok8H//2FwZabC+EFxTYpQ==}
 
-  '@milaboratories/pl-model-common@1.24.6':
-    resolution: {integrity: sha512-FEsjVjJbsBMOvgkrgOhK6p3B7RHBGBmenoq9mfZpVYP2bVd3f557490FG0VvYXgvo9o0fwUzcNLDy3Wqv/ryhg==}
+  '@milaboratories/pl-model-common@1.42.0':
+    resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.11.8':
-    resolution: {integrity: sha512-HEbdJyBpYGStnpaEP7kyLQzvrqoYmlC+UBs1cwtL8yeW2OfyKbff4JvSQ3C8yJ8iTlnuVZ6VYobe/Iyf9dh8hg==}
+  '@milaboratories/pl-model-middle-layer@1.22.0':
+    resolution: {integrity: sha512-MvdNkgPDaAoHnVU3IeeyGfZ9SynJwjsYKnvxNi3YQ9BzztwCDmSwrDijsVvo7lUBoeqLiXvLSr9ug98frKF6yg==}
 
   '@milaboratories/pl-model-middle-layer@1.8.34':
     resolution: {integrity: sha512-0VdpZ67nmX0bWjCjcCR0paGqzJleZ/1TVLdbK71gWuq2jwN6wmBA90t5rDAfRWj7Ju9RkUU7LR5QyuwB/L0OfQ==}
@@ -1214,14 +1225,11 @@ packages:
   '@milaboratories/ptabler-expression-js@1.1.0':
     resolution: {integrity: sha512-B8qDP/f9eqERl7kllsdg0UPW4ZQmZWbPl78GHq6A4+57Qp11SoUJOMCjCEF8Clml0AKWxqter4gQ59k2t1OSGA==}
 
-  '@milaboratories/ptabler-expression-js@1.1.16':
-    resolution: {integrity: sha512-Iu7/f0M3H+Cu+6BunwUqcPDO86coHCavsgANJ8mFdCPvIiYj/du3QdaTzi9rH0YO+9n2i0aFd5+seNL2YvkbJQ==}
-
   '@milaboratories/resolve-helper@1.1.1':
     resolution: {integrity: sha512-0A7yX8p3uhTWAGphq9oV3fGQODtmCgPHEuB0UkUw5MSdAOM4rjQX35IPOi3fVVPumVJxeygqdJZ4sfSRU4+IVA==}
 
-  '@milaboratories/resolve-helper@1.1.2':
-    resolution: {integrity: sha512-xicajvqgaGOdXlKwolwVHdXNB3zRUbvjIiZQWcy2R+3rbScfEaBspnDDstDXKc4nMbieO+8Bq2o7AbtKmheDfw==}
+  '@milaboratories/resolve-helper@1.1.3':
+    resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -1234,15 +1242,15 @@ packages:
   '@milaboratories/ts-helpers-oclif@1.1.30':
     resolution: {integrity: sha512-jBl6/pqsJMK+j1j+hTD9UyVHsxY8EZiVCdsVBHFgRtpTtzhSRvcUYQJVbMn5j3PifFEyDxShOICCce9RZ0umJA==}
 
-  '@milaboratories/ts-helpers-oclif@1.1.37':
-    resolution: {integrity: sha512-DZHhE5CQ3CR+5ZA9T5f+K6kuIsqGNnXNHxQ+tXi/lJwjHwSQL9uwoFPR4xXIHgVoPnf/hm+woN6SAd0BwBJnqQ==}
+  '@milaboratories/ts-helpers-oclif@1.1.41':
+    resolution: {integrity: sha512-rpn1jB2b6p4hcw4Y2iuLM/9X9zqGXacRL1RbZMaB6ebk+2bnmH3CtmfJJdBWW1wfsP80HqmRV8iQrfCI1kzFDA==}
 
   '@milaboratories/ts-helpers@1.5.1':
     resolution: {integrity: sha512-o8w+/6leOpELVk/GN7+bKnTWgTiL+lsIKq/UDtRGNhk6hYIsKfE+vWHGoTswKMvgoqfA0C3cZQ2HjUvo4VDE+w==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ts-helpers@1.7.2':
-    resolution: {integrity: sha512-Ptfxh2SGL7Scqg+uIC5QjBMyqWwq+aldlYhrkURUQaXQcINlBqTYeUIHgb9DjJLj9B/K522uh9iKJ4rjTW1mxA==}
+  '@milaboratories/ts-helpers@1.8.2':
+    resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/uikit@2.2.82':
@@ -1276,9 +1284,6 @@ packages:
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.0':
     resolution: {integrity: sha512-tQw07omRWh7XFNyGDZz1VeiRxjzprvXWxhJI3git3Yf0GlgsCMmdxwSd1gpeORwFU9ggvLTGwdlAMN5KkfFwAw==}
-
-  '@platforma-open/milaboratories.software-ptabler.schema@1.13.9':
-    resolution: {integrity: sha512-g8yqWbNMV8CKHonyC8ZwP86uppsF9OPfZcLm+qM8abKNPxkIHb6jVY3ni9Rzd7wi58gZFdT0SUu/P4nI80JgcA==}
 
   '@platforma-open/milaboratories.software-ptabler@1.13.3':
     resolution: {integrity: sha512-deswcfndJTUyHDgK7GofFn2n3XwtvuUfWS2fF6jZ0cwVkb2wht2FDaAKaIVu7bEDe3FopVC5PXa5D475FAKT7g==}
@@ -1332,16 +1337,16 @@ packages:
     resolution: {integrity: sha512-a5eo8UJ5dV3E3Ps4W9Vv7C/qkuu10oM1F1YUiSeRAOFwBnlsY3RpEfCckQBbPftX6yFs5U0ctGGdTvCuCtg3hQ==}
     hasBin: true
 
-  '@platforma-sdk/block-tools@2.6.48':
-    resolution: {integrity: sha512-mxWnHQX1uxLh+LFEPqT5m3HAGxVhKYUoKkirRxJMRQSjIVSIJNxv//AnPbwdR0sYttzwu3FKXDLPFw7l/jSQ4A==}
+  '@platforma-sdk/block-tools@2.9.2':
+    resolution: {integrity: sha512-DXtZsma9aA5PBRaQzXqf79UMDo07NJrKZb/m4aaio7cxIG2ASG+CEgAkphzkeDcauMMRQ+o1tBQ2g9IptQvTAQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.0.0':
     resolution: {integrity: sha512-cef5ysA011ub5bofbWQJ3EM9rZ7A4ixGMKhFIsF2VNwYrCu5XRHsayA6vDeFOBjX4Jnq9D0QztW0JUxXD73bpw==}
     hasBin: true
 
-  '@platforma-sdk/blocks-deps-updater@2.0.1':
-    resolution: {integrity: sha512-k5BRlBSjsu48v9/u4386Jd7MLv8a0+FMZhAn7vEIc7NR3rTNf/KX8mlFcP/XxNVjLFOGXb9jiR7EJrBZKXvN0g==}
+  '@platforma-sdk/blocks-deps-updater@2.2.0':
+    resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
   '@platforma-sdk/eslint-config@1.1.0':
@@ -1361,9 +1366,6 @@ packages:
 
   '@platforma-sdk/model@1.45.0':
     resolution: {integrity: sha512-AMplDyyW/07D62/heNeh2yVd3Yx36Axq5qhxSIjFNvWnr3QVTxqLuch4OtyKZL1VB8ME6x+8vuNtPCFvrzQe8w==}
-
-  '@platforma-sdk/model@1.53.15':
-    resolution: {integrity: sha512-OUx+tdT/a1B6DlsWu9N4FX40KJFiNKLoSZi8y62HkoUp42CKqa7tX/zUxx4/suTNfsZfqecnAt7Io+7w6sa8JQ==}
 
   '@platforma-sdk/tengo-builder@2.3.3':
     resolution: {integrity: sha512-Wdtnmswk1uv/x5gzGNTvDHPW0uvNP+vvjMwHHShUmR+ShGq8Jc+Ho/eAxFHIiGv9paed1kXZ/VZWzS3S+ma+RQ==}
@@ -4133,9 +4135,6 @@ packages:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
 
-  fast-json-patch@3.1.1:
-    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -4628,6 +4627,12 @@ packages:
 
   one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
+
+  openapi-fetch@0.15.2:
+    resolution: {integrity: sha512-rdYTzUmSsJevmNqg7fwUVGuKc2Gfb9h6ph74EVPkPfIGJaZTfqdIbJahtbJ3qg1LKinln30hqZniLnKpH0RJBg==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5298,6 +5303,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-node@2.1.8:
@@ -5560,6 +5566,9 @@ packages:
 
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -6673,6 +6682,8 @@ snapshots:
 
   '@milaboratories/helpers@1.12.0': {}
 
+  '@milaboratories/helpers@1.14.2': {}
+
   '@milaboratories/helpers@1.6.11': {}
 
   '@milaboratories/miplots4@1.0.105(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
@@ -6788,6 +6799,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@milaboratories/pl-client@3.9.2':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.2
+      openapi-fetch: 0.15.2
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.1
+
   '@milaboratories/pl-config@1.7.6':
     dependencies:
       '@milaboratories/ts-helpers': 1.5.1
@@ -6840,14 +6869,14 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
+  '@milaboratories/pl-error-like@1.12.10':
+    dependencies:
+      json-stringify-safe: 5.0.1
+      zod: 3.25.76
+
   '@milaboratories/pl-error-like@1.12.5':
     dependencies:
       canonicalize: 2.1.0
-      json-stringify-safe: 5.0.1
-      zod: 3.23.8
-
-  '@milaboratories/pl-error-like@1.12.8':
-    dependencies:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
@@ -6866,7 +6895,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@milaboratories/pl-http@1.2.3':
+  '@milaboratories/pl-http@1.2.4':
     dependencies:
       undici: 7.16.0
 
@@ -6912,6 +6941,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@milaboratories/pl-model-backend@1.3.5':
+    dependencies:
+      '@milaboratories/pl-client': 3.9.2
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-common@1.15.3':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.1
@@ -6930,19 +6965,20 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.24.6':
+  '@milaboratories/pl-model-common@1.42.0':
     dependencies:
-      '@milaboratories/pl-error-like': 1.12.8
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
-      zod: 3.23.8
+      zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.11.8':
+  '@milaboratories/pl-model-middle-layer@1.22.0':
     dependencies:
-      '@milaboratories/pl-model-common': 1.24.6
-      '@platforma-sdk/model': 1.53.15
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.42.0
       es-toolkit: 1.40.0
       utility-types: 3.11.0
-      zod: 3.23.8
+      zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.8.34':
     dependencies:
@@ -6975,13 +7011,9 @@ snapshots:
     dependencies:
       '@platforma-open/milaboratories.software-ptabler.schema': 1.12.0
 
-  '@milaboratories/ptabler-expression-js@1.1.16':
-    dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.13.9
-
   '@milaboratories/resolve-helper@1.1.1': {}
 
-  '@milaboratories/resolve-helper@1.1.2': {}
+  '@milaboratories/resolve-helper@1.1.3': {}
 
   '@milaboratories/software-pframes-conv@2.2.9': {}
 
@@ -6992,9 +7024,9 @@ snapshots:
       '@milaboratories/ts-helpers': 1.5.1
       '@oclif/core': 4.0.37
 
-  '@milaboratories/ts-helpers-oclif@1.1.37':
+  '@milaboratories/ts-helpers-oclif@1.1.41':
     dependencies:
-      '@milaboratories/ts-helpers': 1.7.2
+      '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.0.37
 
   '@milaboratories/ts-helpers@1.5.1':
@@ -7002,8 +7034,9 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/ts-helpers@1.7.2':
+  '@milaboratories/ts-helpers@1.8.2':
     dependencies:
+      '@milaboratories/helpers': 1.14.2
       canonicalize: 2.1.0
       denque: 2.1.0
 
@@ -7055,10 +7088,6 @@ snapshots:
   '@platforma-open/milaboratories.software-mixcr@4.7.0-303-develop': {}
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.0': {}
-
-  '@platforma-open/milaboratories.software-ptabler.schema@1.13.9':
-    dependencies:
-      '@milaboratories/pl-model-common': 1.24.6
 
   '@platforma-open/milaboratories.software-ptabler@1.13.3': {}
 
@@ -7127,24 +7156,25 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@platforma-sdk/block-tools@2.6.48':
+  '@platforma-sdk/block-tools@2.9.2':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
-      '@milaboratories/pl-http': 1.2.3
-      '@milaboratories/pl-model-common': 1.24.6
-      '@milaboratories/pl-model-middle-layer': 1.11.8
-      '@milaboratories/resolve-helper': 1.1.2
-      '@milaboratories/ts-helpers': 1.7.2
-      '@milaboratories/ts-helpers-oclif': 1.1.37
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-backend': 1.3.5
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.22.0
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers-oclif': 1.1.41
       '@oclif/core': 4.0.37
-      '@platforma-sdk/blocks-deps-updater': 2.0.1
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
       canonicalize: 2.1.0
       lru-cache: 11.2.2
       mime-types: 2.1.35
       tar: 7.4.3
       undici: 7.16.0
       yaml: 2.8.1
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
       - aws-crt
 
@@ -7152,7 +7182,7 @@ snapshots:
     dependencies:
       yaml: 2.8.1
 
-  '@platforma-sdk/blocks-deps-updater@2.0.1':
+  '@platforma-sdk/blocks-deps-updater@2.2.0':
     dependencies:
       yaml: 2.8.1
 
@@ -7181,17 +7211,6 @@ snapshots:
       '@milaboratories/pl-model-common': 1.21.4
       '@milaboratories/ptabler-expression-js': 1.1.0
       canonicalize: 2.1.0
-      utility-types: 3.11.0
-      zod: 3.23.8
-
-  '@platforma-sdk/model@1.53.15':
-    dependencies:
-      '@milaboratories/pl-error-like': 1.12.8
-      '@milaboratories/pl-model-common': 1.24.6
-      '@milaboratories/ptabler-expression-js': 1.1.16
-      canonicalize: 2.1.0
-      es-toolkit: 1.40.0
-      fast-json-patch: 3.1.1
       utility-types: 3.11.0
       zod: 3.23.8
 
@@ -10910,8 +10929,6 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-json-patch@3.1.1: {}
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -11328,6 +11345,12 @@ snapshots:
   one-time@1.0.0:
     dependencies:
       fn.name: 1.1.0
+
+  openapi-fetch@0.15.2:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
 
   optionator@0.9.4:
     dependencies:
@@ -12242,3 +12265,5 @@ snapshots:
   zod@3.23.8: {}
 
   zod@3.24.2: {}
+
+  zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
   - test
 
 catalog:
-  '@platforma-sdk/tengo-builder': ^2.3.3
+  '@platforma-sdk/tengo-builder': ^3.0.5
   '@platforma-sdk/block-tools': 2.9.2
   '@platforma-sdk/eslint-config': ^1.1.0
   '@platforma-sdk/blocks-deps-updater': ^2.0.0
@@ -17,7 +17,7 @@ catalog:
   '@platforma-sdk/test': ^1.45.11
   '@milaboratories/graph-maker': 1.1.98
 
-  '@platforma-sdk/workflow-tengo': ^5.5.9
+  '@platforma-sdk/workflow-tengo': ^5.26.0
 
   '@platforma-open/milaboratories.software-small-binaries': ^1.15.19
   '@platforma-open/milaboratories.software-mixcr': 4.7.0-303-develop

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 
 catalog:
   '@platforma-sdk/tengo-builder': ^2.3.3
-  '@platforma-sdk/block-tools': 2.6.48
+  '@platforma-sdk/block-tools': 2.9.2
   '@platforma-sdk/eslint-config': ^1.1.0
   '@platforma-sdk/blocks-deps-updater': ^2.0.0
 

--- a/ui/src/pages/components/MainSettingsPanel.vue
+++ b/ui/src/pages/components/MainSettingsPanel.vue
@@ -78,10 +78,6 @@ function getDatasetOptions(idx: number): ListOption<RefString | undefined>[] | u
     label="Select donor column" clearable />
 
   <template v-if="app.model.args.donorColumn !== undefined">
-    <PlAlert v-if="app.model.outputs.infoMessage" type="info">
-      {{ app.model.outputs.infoMessage }}
-    </PlAlert>
-
     <template v-for="dsIdx in range(0, app.model.args.datasetColumns.length + 1)" :key="dsIdx">
       <!-- Slot is rendered when:
            (a) it shows an existing selection (dsIdx is in range),
@@ -98,6 +94,10 @@ function getDatasetOptions(idx: number): ListOption<RefString | undefined>[] | u
         :label="`${dsIdx === app.model.args.datasetColumns.length ? 'Add' : 'Select'} dataset #${dsIdx + 1}`"
       />
     </template>
+
+    <PlAlert v-if="app.model.outputs.infoMessage" type="info">
+      {{ app.model.outputs.infoMessage }}
+    </PlAlert>
   </template>
 
   <PlAccordionSection label="Downsampling (Bulk Datasets Only)">

--- a/ui/src/pages/components/MainSettingsPanel.vue
+++ b/ui/src/pages/components/MainSettingsPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { notEmpty, range } from '@milaboratories/helpers';
-import { ListOption, PlAccordionSection, PlDropdown, PlDropdownRef, PlNumberField, PlSectionSeparator } from '@platforma-sdk/ui-vue';
+import { ListOption, PlAccordionSection, PlAlert, PlDropdown, PlDropdownRef, PlNumberField, PlSectionSeparator } from '@platforma-sdk/ui-vue';
 import { computed } from 'vue';
 import { useApp } from '../../app';
 import { fromRefString, RefString, toRefString } from '../../util';
@@ -78,13 +78,24 @@ function getDatasetOptions(idx: number): ListOption<RefString | undefined>[] | u
     label="Select donor column" clearable />
 
   <template v-if="app.model.args.donorColumn !== undefined">
+    <PlAlert v-if="app.model.outputs.infoMessage" type="info">
+      {{ app.model.outputs.infoMessage }}
+    </PlAlert>
+
     <template v-for="dsIdx in range(0, app.model.args.datasetColumns.length + 1)" :key="dsIdx">
-      <PlDropdown 
-        v-if="getDatasetOptions(dsIdx)?.length !== 0" 
-        :options="getDatasetOptions(dsIdx)"
-        :model-value="getDatasetValue(dsIdx)" 
+      <!-- Slot is rendered when:
+           (a) it shows an existing selection (dsIdx is in range),
+           (b) the user has no datasets selected yet (always offer "Add"),
+           (c) options resolved to a non-empty list, OR
+           (d) options are still loading (?? 1 keeps the slot visible during reactive transitions). -->
+      <PlDropdown
+        v-if="dsIdx < app.model.args.datasetColumns.length
+              || app.model.args.datasetColumns.length === 0
+              || (getDatasetOptions(dsIdx)?.length ?? 1) !== 0"
+        :options="getDatasetOptions(dsIdx) ?? []"
+        :model-value="getDatasetValue(dsIdx)"
         @update:model-value="(v) => datasetValueSetter(dsIdx, v)"
-        :label="`${dsIdx === app.model.args.datasetColumns.length ? 'Add' : 'Select'} dataset #${dsIdx + 1}`" 
+        :label="`${dsIdx === app.model.args.datasetColumns.length ? 'Add' : 'Select'} dataset #${dsIdx + 1}`"
       />
     </template>
   </template>


### PR DESCRIPTION
## Bug

Picking a donor column in MiXCR SHM Trees hides the "Add dataset" dropdown silently when `outputs.datasetOptions === []`. Block unrunnable; no feedback.

## Fix

- **Model:** new `infoMessage` output classifies why no datasets are eligible (`classifyClnsSpec` → `eligible | not-clns | axes-mismatch | cdr3-only | missing-annotation`) and emits one of six cause-specific strings. Shared `isEligibleClnsSpec` wrapper keeps `datasetOptions` in lock-step.
- **UI:** new `PlAlert type="info"` renders `outputs.infoMessage` below the dataset slots. Widened "Add" v-if keeps the slot visible during loading and when no datasets are eligible.
- **Deps:** bump `block-tools` → 2.9.2, `tengo-builder` → ^3.0.5, `workflow-tengo` → ^5.26.0 (CI `require-latest` + 3.x rejected old `importSoftware` syntax).

## Message table

| Situation | Message |
|---|---|
| Selected datasets all stale (donor switched) | *Selected datasets are incompatible with this donor column. Clear them or switch back to the previous donor.* |
| Pool has zero clns at all | *No clonotype data yet. Add a clonotyping block upstream.* |
| All clns fail by axes only | *Available clonotype data uses a different sample axis than this donor column. Pick a donor column from the same dataset as your clonotyping.* |
| All clns fail by CDR3 only | *SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). The list refreshes after each clonotyping run.* |
| All clns fail by missing annotation only | *Available clonotype data lacks metadata SHM trees needs. Re-run clonotyping with a current version.* |
| Mixed failure causes | *Available clonotype data is incompatible with this donor column. SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion) on a matching sample axis.* |

## Blocks producing `mixcr.com/clns`

`mixcr-clonotyping`, `mixcr-amplicon-alignment`, `mixcr-scfv-clonotyping`, `miltenyi-tcr-bcr-clonotyping`, `cellecta-drivermap-air-mixcr-clonotyping`.

## Out of scope

Pre-existing `datasetOptionsMap` hairpin at `MainSettingsPanel.vue:11-22` (computed writes to `args.datasetsTitles`). Falls under the harness's block-label exception. Separate PR.

## Spec & plan

- `docs/text/work/ad-hoc/2026-05-27-milab-6319-shm-trees-info-message-spec.md`
- `docs/text/work/ad-hoc/2026-05-27-milab-6319-shm-trees-info-message-plan.md`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR surfaces a model-side `infoMessage` output when the selected donor column has no eligible clonotype datasets, and keeps the "Add dataset" dropdown visible so the block remains navigable even in the empty-options state.

- **Model:** Introduces `classifyClnsSpec` (returning a `ClnsClassification` union) and `isEligibleClnsSpec` (a boolean wrapper), replacing the inline filter in `datasetOptions` and powering per-cause messages in `infoMessage`. A new `axesSpec.length === 0` guard protects both outputs from axis-less metadata columns. The switch statement is exhaustiveness-guarded with `_exhaustive: never`.
- **UI:** The `PlDropdown` `v-if` is expanded to a three-part OR — existing selections always render, the "Add" slot is always shown when no datasets are selected, and it shows during loading (via `?? 1`). A `PlAlert type="info"` below the slots renders `infoMessage` when non-null.
- **Deps:** `block-tools` → 2.9.2, `tengo-builder` → ^3.0.5, `workflow-tengo` → ^5.26.0 in the workspace catalog.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive (new output, widened v-if, new alert) and does not alter existing data-flow paths or arg mutation.

The classification logic is exhaustiveness-guarded, the defensive axesSpec.length === 0 guard prevents a latent crash on axis-less metadata columns, and the UI visibility conditions handle all three states (loading, empty, non-empty) correctly. No existing outputs or args were modified; the SDK dependency bumps are straightforward catalog-level updates.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/index.ts | Adds classifyClnsSpec/isEligibleClnsSpec helpers and a new infoMessage output with per-cause messages; also adds a defensive axesSpec.length === 0 guard to both datasetOptions and infoMessage. Logic is sound and exhaustiveness-guarded. |
| ui/src/pages/components/MainSettingsPanel.vue | Widens the PlDropdown v-if so the Add dataset slot stays visible when no datasets are selected or during loading, and adds a PlAlert bound to infoMessage. The three-part OR condition correctly handles all slot-visibility cases. |
| pnpm-workspace.yaml | Bumps block-tools to 2.9.2, tengo-builder to ^3.0.5, and workflow-tengo to ^5.26.0 in the workspace catalog. |
| .changeset/milab-6319-info-message.md | Patch-level changeset for both model and UI packages; description accurately matches the change. |
| pnpm-lock.yaml | Lockfile updated to resolve bumped SDK dependencies and their transitive graph; no manual edits, generated correctly. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([donorColumn selected]) --> B{axesSpec.length === 0?}
    B -- yes --> C[return undefined]
    B -- no --> D[resolve sampleAxisId]
    D --> E{datasetColumns.length > 0?}
    E -- yes --> F{any selected ref still eligible?}
    F -- yes --> G[infoMessage = undefined]
    F -- no --> H[infoMessage = Selected datasets incompatible]
    E -- no --> I[filter pool for mixcr.com/clns specs]
    I --> J{clnsSpecs.length === 0?}
    J -- yes --> K[infoMessage = No clonotype data yet]
    J -- no --> L[classify each spec]
    L --> M{any eligible?}
    M -- yes --> N[infoMessage = undefined]
    M -- no --> O{causes.size === 1?}
    O -- axes-mismatch --> P[infoMessage = Different sample axis]
    O -- cdr3-only --> Q[infoMessage = Needs broader assembling feature]
    O -- missing-annotation --> R[infoMessage = Lacks metadata]
    O -- mixed --> S[infoMessage = generic fallback]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["MILAB-6319: guard axis-less donor column..."](https://github.com/platforma-open/mixcr-shm-trees/commit/87183ad0a76e9da6199b30935dbde9ca9e355b95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34253154)</sub>

<!-- /greptile_comment -->