### PR TITLE
MILAB-6319: distinct infoMessage per rejection cause

### DIFF
--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -134,15 +134,13 @@ function treeNodesColumns(
 
 const InBasketPColumnName = 'pl7.app/dendrogram/inBasket';
 
-// Classification of why a mixcr.com/clns p-column might fail SHM trees' filter,
+// Classification of why a PColumnSpec might fail SHM trees' clns filter,
 // or 'eligible' if it passes. Used by datasetOptions (boolean eligibility) and
 // by infoMessage (cause-specific user messages).
-type ClnsClassification = 'eligible' | 'axes-mismatch' | 'cdr3-only' | 'missing-annotation';
+type ClnsClassification = 'eligible' | 'not-clns' | 'axes-mismatch' | 'cdr3-only' | 'missing-annotation';
 
 function classifyClnsSpec(spec: PColumnSpec, sampleAxisId: AxisId): ClnsClassification {
-  // Caller should pre-filter to name === 'mixcr.com/clns'; non-clns specs are
-  // categorised as missing-annotation to keep this total.
-  if (spec.name !== 'mixcr.com/clns') return 'missing-annotation';
+  if (spec.name !== 'mixcr.com/clns') return 'not-clns';
   if (!matchAxesId([sampleAxisId], spec.axesSpec)) return 'axes-mismatch';
   const af = spec.annotations?.['mixcr.com/assemblingFeature'];
   if (af === undefined) return 'missing-annotation';
@@ -325,15 +323,30 @@ export const model = BlockModel.create()
     const causes = new Set(classifications);
 
     if (causes.size === 1) {
-      if (causes.has('axes-mismatch'))
-        return 'Available clonotype data uses a different sample axis than this donor column. '
-          + 'Pick a donor column from the same dataset as your clonotyping.';
-      if (causes.has('cdr3-only'))
-        return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
-          + 'The list refreshes after each clonotyping run.';
-      if (causes.has('missing-annotation'))
-        return 'Available clonotype data lacks metadata SHM trees needs. '
-          + 'Re-run clonotyping with a current version.';
+      const [onlyCause] = [...causes];
+      switch (onlyCause) {
+        case 'axes-mismatch':
+          return 'Available clonotype data uses a different sample axis than this donor column. '
+            + 'Pick a donor column from the same dataset as your clonotyping.';
+        case 'cdr3-only':
+          return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
+            + 'The list refreshes after each clonotyping run.';
+        case 'missing-annotation':
+          return 'Available clonotype data lacks metadata SHM trees needs. '
+            + 'Re-run clonotyping with a current version.';
+        case 'eligible':
+        case 'not-clns':
+          // Unreachable in this branch: 'eligible' was excluded above, and clnsSpecs
+          // was already pre-filtered to spec.name === 'mixcr.com/clns'. Fall through
+          // to the mixed-causes fallback below.
+          break;
+        default: {
+          // Compile-time exhaustiveness guard: adding a new ClnsClassification
+          // variant must add a case here.
+          const _exhaustive: never = onlyCause;
+          void _exhaustive;
+        }
+      }
     }
 
     // Mixed causes — pool has clns that fail for different reasons. Fall back

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -134,15 +134,28 @@ function treeNodesColumns(
 
 const InBasketPColumnName = 'pl7.app/dendrogram/inBasket';
 
-// Shared filter used by datasetOptions and infoMessage so they stay in lock-step.
-function isEligibleClnsSpec(spec: PColumnSpec, sampleAxisId: AxisId): boolean {
-  if (spec.name !== 'mixcr.com/clns') return false;
-  if (!matchAxesId([sampleAxisId], spec.axesSpec)) return false;
+// Classification of why a mixcr.com/clns p-column might fail SHM trees' filter,
+// or 'eligible' if it passes. Used by datasetOptions (boolean eligibility) and
+// by infoMessage (cause-specific user messages).
+type ClnsClassification = 'eligible' | 'axes-mismatch' | 'cdr3-only' | 'missing-annotation';
+
+function classifyClnsSpec(spec: PColumnSpec, sampleAxisId: AxisId): ClnsClassification {
+  // Caller should pre-filter to name === 'mixcr.com/clns'; non-clns specs are
+  // categorised as missing-annotation to keep this total.
+  if (spec.name !== 'mixcr.com/clns') return 'missing-annotation';
+  if (!matchAxesId([sampleAxisId], spec.axesSpec)) return 'axes-mismatch';
   const af = spec.annotations?.['mixcr.com/assemblingFeature'];
-  if (af === undefined || af === 'CDR3' || af === '[CDR3]') return false;
+  if (af === undefined) return 'missing-annotation';
+  if (af === 'CDR3' || af === '[CDR3]') return 'cdr3-only';
   const cfoe = spec.annotations?.['mixcr.com/coveredFeaturesOnExport'];
-  if (cfoe === undefined || cfoe === '') return false;
-  return true;
+  if (cfoe === undefined || cfoe === '') return 'missing-annotation';
+  return 'eligible';
+}
+
+// Boolean wrapper around classifyClnsSpec for datasetOptions, which only cares
+// about the binary outcome.
+function isEligibleClnsSpec(spec: PColumnSpec, sampleAxisId: AxisId): boolean {
+  return classifyClnsSpec(spec, sampleAxisId) === 'eligible';
 }
 
 type BasketColumns = {
@@ -282,28 +295,52 @@ export const model = BlockModel.create()
 
     const sampleAxisId = getAxisId(donorColumnSpec.axesSpec[0]);
 
+    // Stale-selections case: dataset slots are filled, but none of the selected
+    // refs is still eligible under the current donor (e.g. donor was switched).
     if (ctx.args.datasetColumns.length > 0) {
-      // Datasets are already selected. Suppress the message only when at least
-      // one selection is still eligible for the current donor. This catches the
-      // donor-switch case where the new donor's sample axis no longer matches
-      // the previously-selected clns columns.
       const anySelectedEligible = ctx.args.datasetColumns.some((ref) => {
         const spec = ctx.resultPool.getSpecByRef(ref);
         return spec !== undefined && isPColumnSpec(spec) && isEligibleClnsSpec(spec, sampleAxisId);
       });
       if (anySelectedEligible) return undefined;
-    } else {
-      // No datasets selected yet. Suppress the message only when the result pool
-      // has at least one eligible clns p-column the user could pick.
-      const hasAnyEligible = ctx.resultPool
-        .getSpecs()
-        .entries.filter(isPColumnSpecResult)
-        .some(({ obj: spec }) => isEligibleClnsSpec(spec, sampleAxisId));
-      if (hasAnyEligible) return undefined;
+      return 'Selected datasets are incompatible with this donor column. '
+        + 'Clear them or switch back to the previous donor.';
     }
 
-    return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
-      + 'The list refreshes after each clonotyping run.';
+    // No datasets selected. Classify every clns spec in the pool so the message
+    // names the actual reason ineligibility, not just "CDR3".
+    const clnsSpecs = ctx.resultPool
+      .getSpecs()
+      .entries.filter(isPColumnSpecResult)
+      .map(({ obj: spec }) => spec)
+      .filter((spec) => spec.name === 'mixcr.com/clns');
+
+    if (clnsSpecs.length === 0) {
+      return 'No clonotype data yet. Add a clonotyping block upstream.';
+    }
+
+    const classifications = clnsSpecs.map((spec) => classifyClnsSpec(spec, sampleAxisId));
+    if (classifications.includes('eligible')) return undefined;
+
+    const causes = new Set(classifications);
+
+    if (causes.size === 1) {
+      if (causes.has('axes-mismatch'))
+        return 'Available clonotype data uses a different sample axis than this donor column. '
+          + 'Pick a donor column from the same dataset as your clonotyping.';
+      if (causes.has('cdr3-only'))
+        return 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). '
+          + 'The list refreshes after each clonotyping run.';
+      if (causes.has('missing-annotation'))
+        return 'Available clonotype data lacks metadata SHM trees needs. '
+          + 'Re-run clonotyping with a current version.';
+    }
+
+    // Mixed causes — pool has clns that fail for different reasons. Fall back
+    // to a generic message that covers the dominant remediation paths.
+    return 'Available clonotype data is incompatible with this donor column. '
+      + 'SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion) '
+      + 'on a matching sample axis.';
   })
 
   .output('treeNodes', (ctx) => {


### PR DESCRIPTION
Stacked on #113. Addresses the deferred follow-up flagged in that PR's review thread (Greptile P2): the single generic message blamed CDR3 even when the actual cause was axes mismatch, missing annotation, or no clonotyping at all.

## Change

- New \`ClnsClassification\` type and \`classifyClnsSpec\` helper return the *reason* a clns p-column fails the filter: \`eligible | axes-mismatch | cdr3-only | missing-annotation\`.
- \`isEligibleClnsSpec\` is now a one-line wrapper over \`classifyClnsSpec\` — \`datasetOptions\` semantics unchanged.
- \`infoMessage\` walks every clns spec in the pool, sets up the cause set, and emits one of six messages.

## Message table

| Situation | Message |
|---|---|
| Selected datasets all stale (donor switched) | *Selected datasets are incompatible with this donor column. Clear them or switch back to the previous donor.* |
| Pool has zero clns at all | *No clonotype data yet. Add a clonotyping block upstream.* |
| All clns fail by axes only | *Available clonotype data uses a different sample axis than this donor column. Pick a donor column from the same dataset as your clonotyping.* |
| All clns fail by CDR3 only | *SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion). The list refreshes after each clonotyping run.* |
| All clns fail by missing annotation only | *Available clonotype data lacks metadata SHM trees needs. Re-run clonotyping with a current version.* |
| Mixed failure causes | *Available clonotype data is incompatible with this donor column. SHM trees needs an assembling feature broader than CDR3 (e.g. VDJRegion) on a matching sample axis.* |

## Out of scope

No UI changes. The \`PlAlert\` still renders \`outputs.infoMessage\` as a single string.

## Test plan

- [ ] CDR3 case (preset \`milab-human-rna-tcr-umi-multiplex\` reproducer) — message reads *"...broader than CDR3 (e.g. VDJRegion)..."*
- [ ] No-clns case — Samples & Data + SHM Trees, no clonotyping — message reads *"No clonotype data yet..."*
- [ ] Stale-selections — select datasets in a working project, delete the clonotyping block — message reads *"Selected datasets are incompatible..."*
- [ ] Axes mismatch — donor metadata from dataset A, clonotyping only on dataset B (different sample axis) — message reads *"...different sample axis..."*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the single-cause `isEligibleClnsSpec` predicate with a richer `classifyClnsSpec` helper that returns a `ClnsClassification` discriminant, then uses those discriminants in `infoMessage` to emit one of six targeted user messages instead of always blaming CDR3.

- `ClnsClassification` (`eligible | not-clns | axes-mismatch | cdr3-only | missing-annotation`) is introduced; `isEligibleClnsSpec` becomes a one-liner wrapper, leaving `datasetOptions` semantics unchanged.
- `infoMessage` now walks every `mixcr.com/clns` spec in the pool, collects the rejection causes into a `Set`, and dispatches a dedicated message per single-cause pool or a generic mixed-causes fallback.
- The single-cause `switch` carries a `default` exhaustiveness guard (`const _exhaustive: never = onlyCause`) so adding a new `ClnsClassification` variant produces a compile error until a new case is added — addressing the concern raised in the previous review.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive message logic with no effect on data flow or eligibility semantics.

The classification logic correctly pre-filters specs to `mixcr.com/clns` before calling `classifyClnsSpec`, so `not-clns` cannot appear in the cause set at runtime. The switch exhaustiveness guard genuinely catches new variants at compile time. `isEligibleClnsSpec` remains a boolean wrapper so `datasetOptions` output is unaffected. Both concerns raised in the previous review thread have been resolved correctly.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/index.ts | Replaces single boolean filter with a typed classification enum and cause-set dispatch; logic is correct, exhaustiveness guard is wired up, and pre-filtering ensures `not-clns` cannot appear in the `causes` set at runtime. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[infoMessage called] --> B{donorColumn defined?}
    B -- No --> Z[return undefined]
    B -- Yes --> C{datasetColumns selected?}
    C -- Yes --> D{any selected spec eligible?}
    D -- Yes --> Z
    D -- No --> E[return: Selected datasets incompatible]
    C -- No --> F[collect all clns specs from pool]
    F --> G{clnsSpecs.length === 0?}
    G -- Yes --> H[return: No clonotype data yet]
    G -- No --> I[classifyClnsSpec for each spec]
    I --> J{any eligible?}
    J -- Yes --> Z
    J -- No --> K[build causes Set]
    K --> L{causes.size === 1?}
    L -- No --> M[return: mixed-causes fallback]
    L -- Yes --> N{onlyCause}
    N -- axes-mismatch --> O[return: different sample axis]
    N -- cdr3-only --> P[return: needs broader assembling feature]
    N -- missing-annotation --> Q[return: lacks metadata, re-run]
    N -- eligible/not-clns --> M
    N -- unknown --> R[_exhaustive: never — compile error]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["MILAB-6319: tighten classifyClnsSpec con..."](https://github.com/platforma-open/mixcr-shm-trees/commit/54ca41686ff1dffad3a4c0c921c4930e98b2e02b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34262883)</sub>

<!-- /greptile_comment -->