### PR TITLE
Julenmendieta/fixBrokenBlock

### DIFF
--- a/.changeset/free-lemons-feel.md
+++ b/.changeset/free-lemons-feel.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-shm-trees.workflow': patch
+---
+
+Fix broken block after workflow-tengo update

--- a/workflow/src/mixcr-export.tpl.tengo
+++ b/workflow/src/mixcr-export.tpl.tengo
@@ -47,7 +47,6 @@ self.body(func(inputs) {
     // export trees without nodes
     shmTreeExportsCmdBuilder := exec.builder().
         printErrStreamToStdout().
-        dontSaveStdoutOrStderr().
         inLightQueue().
         secret("MI_LICENSE", "MI_LICENSE").
         env("MI_LICENSE_DEBUG", "MI_LICENSE_DEBUG").
@@ -83,7 +82,6 @@ self.body(func(inputs) {
     // export tree nodes with data uniq for the node
     shmTreeNodesExportsCmdBuilder := exec.builder().
         printErrStreamToStdout().
-        dontSaveStdoutOrStderr().
         inLightQueue().
         secret("MI_LICENSE", "MI_LICENSE").
         env("MI_LICENSE_DEBUG", "MI_LICENSE_DEBUG").
@@ -119,7 +117,6 @@ self.body(func(inputs) {
     // export nodes with clones. For each node could be several clones
     shmTreeNodesWithClonesExportsCmdBuilder := exec.builder().
         printErrStreamToStdout().
-        dontSaveStdoutOrStderr().
         inLightQueue().
 		secret("MI_LICENSE", "MI_LICENSE").
 		env("MI_LICENSE_DEBUG", "MI_LICENSE_DEBUG").

--- a/workflow/src/mixcr-shm-trees.tpl.tengo
+++ b/workflow/src/mixcr-shm-trees.tpl.tengo
@@ -56,6 +56,7 @@ self.body(func(inputs) {
 
     allelesCmdBuilder := exec.builder().
         printErrStreamToStdout().
+        saveStdoutStream().
         secret("MI_LICENSE", "MI_LICENSE").
         env("MI_LICENSE_DEBUG", "MI_LICENSE_DEBUG").
         env("MI_PROGRESS_PREFIX", progressPrefix).
@@ -178,6 +179,7 @@ self.body(func(inputs) {
 
     shmTreesCmdBuilder := exec.builder().
         printErrStreamToStdout().
+        saveStdoutStream().
         secret("MI_LICENSE", "MI_LICENSE").
         env("MI_LICENSE_DEBUG", "MI_LICENSE_DEBUG").
         env("MI_PROGRESS_PREFIX", progressPrefix).


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This patch adapts two workflow Tengo templates to a breaking change in the `workflow-tengo` SDK where `dontSaveStdoutOrStderr()` was removed and explicit stdout capture now requires calling `saveStdoutStream()`.

- **`mixcr-export.tpl.tengo`**: Removes the three `dontSaveStdoutOrStderr()` calls from the export command builders; none of these builders return stdout streams, so no additional changes are needed.
- **`mixcr-shm-trees.tpl.tengo`**: Adds `saveStdoutStream()` to `allelesCmdBuilder` and `shmTreesCmdBuilder`, enabling the `getStdoutStream()` calls that populate the `allelesLog` and `treesLog` outputs returned by the block.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are a minimal, targeted adaptation to a SDK API change with no logic alterations.

Every builder that calls getStdoutStream() on its result now has a matching saveStdoutStream(), and every builder that does not need stdout capture has no such call. The removal of the defunct dontSaveStdoutOrStderr() from the export builders is consistent because those builders only use getFile() on their results. No logic, arguments, file mappings, or output fields were changed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/free-lemons-feel.md | New changeset file correctly marking this as a patch-level fix to the workflow package. |
| workflow/src/mixcr-export.tpl.tengo | Removes three `dontSaveStdoutOrStderr()` calls that were dropped from the workflow-tengo SDK; none of the three export builders use `getStdoutStream()` in their outputs, so the removal is correct and self-consistent. |
| workflow/src/mixcr-shm-trees.tpl.tengo | Adds `saveStdoutStream()` to `allelesCmdBuilder` and `shmTreesCmdBuilder`, which correctly pairs with the `getStdoutStream()` calls returned as `allelesLog` and `treesLog`; the downsampling builder is left unchanged because its stdout is not returned. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[exec.builder] --> B[printErrStreamToStdout]
    B --> C{Needs stdout log?}
    C -- Yes: alleles & shmTrees builders --> D[saveStdoutStream]
    C -- No: export & downsampling builders --> E[No stdout capture]
    D --> F[.run]
    E --> F
    F --> G{Output type}
    G -- shm-trees --> H[getStdoutStream → allelesLog / treesLog]
    G -- export --> I[getFile output.tsv]
    G -- downsampling --> J[getFile clones.downsampled.clns]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/mixcr-shm-trees/commit/be7d5acb1593ad5a9638b3254b67d095a6091753) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36438074)</sub>

<!-- /greptile_comment -->