### PR TITLE
Bump @platforma-sdk/workflow-tengo version

### DIFF
--- a/.changeset/twelve-humans-kiss.md
+++ b/.changeset/twelve-humans-kiss.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.mixcr-shm-trees': minor
+'@platforma-open/milaboratories.mixcr-shm-trees.workflow': minor
+---
+
+Bump @platforma-sdk/workflow-tengo version

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: 1.31.11
       version: 1.31.11
     '@platforma-sdk/workflow-tengo':
-      specifier: ^5.26.0
-      version: 5.26.0
+      specifier: ^6.6.5
+      version: 6.6.5
     '@vitejs/plugin-vue':
       specifier: ^5.2.4
       version: 5.2.4
@@ -239,7 +239,7 @@ importers:
     dependencies:
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.26.0
+        version: 6.6.5
     devDependencies:
       '@platforma-open/milaboratories.software-mitool':
         specifier: 'catalog:'
@@ -1284,8 +1284,8 @@ packages:
     resolution: {integrity: sha512-qr5lnaJSnI7PmZMh+/PJXOURe3jKSFLWiqo1Ha1OSbY0JwHOmpU8n2aZOGjwscLLTk8AgF6Jfv5t/kPhGk348g==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.35':
-    resolution: {integrity: sha512-kcR9YLWAbKYSpksPOoJWkcrkSiUUAEKj/Wuyc9aFsd2bNbWcIb7mLGptFOuvhLn07bZHn0oNcVgupEqd/6Ftbw==}
+  '@milaboratories/pframes-rs-wasip2@1.1.52':
+    resolution: {integrity: sha512-0rb0We6Q/aqrHJ062dayvLb4RExODZdqfsVWdzeHq23alY5TjJRMWsO9aKQpPnOuUKjAimdjlp+Ldq9TVhbEtg==}
 
   '@milaboratories/pl-client@2.16.1':
     resolution: {integrity: sha512-XcFa5xBpQQ/jJwyEWXEwuX8yiqsUCmGSzaywvShcsJOOuSkX/u8gV5bIIgivV6X7nJt1yX+mukaugo4wjkZZoQ==}
@@ -1422,8 +1422,8 @@ packages:
   '@platforma-open/milaboratories.software-ptabler@1.13.3':
     resolution: {integrity: sha512-deswcfndJTUyHDgK7GofFn2n3XwtvuUfWS2fF6jZ0cwVkb2wht2FDaAKaIVu7bEDe3FopVC5PXa5D475FAKT7g==}
 
-  '@platforma-open/milaboratories.software-ptabler@1.16.1':
-    resolution: {integrity: sha512-m4tzKYlopjHLYpRLSjIqEtFr0QP7MuweaMCTEmr6a+gIVE+x9MKawdXwNwo1A/2QuatygIcGRvIcIz34WibZMA==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.3':
+    resolution: {integrity: sha512-4cikdkdJ5WYc0Nw3IoZxzlFNKvG1qCAqSjypq5b18pIK6LBDayzhFcuw5TDd8O3bAFhoHP+3cVTmoO9XUTYMRg==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.0':
     resolution: {integrity: sha512-7dKhQyecDcxjRNOS9XRgLemZpOuJ3dKMryrBbbkYR6VLKj566tJkbKiC7p1wAWEtHKHEZUhCQYgTZfEtwHCkDA==}
@@ -1451,6 +1451,9 @@ packages:
 
   '@platforma-open/milaboratories.software-small-binaries.java-stub@1.0.4':
     resolution: {integrity: sha512-nr0H+TZDKUR7dpxY5Q5Gh1FOT9Jx4Sr0Uk6jO2I18jJaOPchEPY+gOxemPJO30SNkkkbQiIRBBJYF54tMFiesA==}
+
+  '@platforma-open/milaboratories.software-small-binaries.line-counter@1.1.1':
+    resolution: {integrity: sha512-3bqn2ZK/dV5IR0Zp678Ea9lGSHjLvfRv4lyRBYXZNO1mMWIlEhtT0bmn6FhNzBBj+MhTQfSRFnEsOejtfdN1Ew==}
 
   '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.1':
     resolution: {integrity: sha512-4dJnBVFqxFgFznepUQAMJceWcJrGE2Ms5LH+2BMjG/qOFJpEAiWJlrjiobiapqf2jnJgxM1AcDVR9M67uGrySA==}
@@ -1485,8 +1488,8 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@1.15.23':
     resolution: {integrity: sha512-I1G2qEWALvNAJy9kOTXjryu0GvK+hvUCVPckNhGkFO/cGIsST7R7s9pm0exhG92PyuLFa5lwJFx/fgobqWUWNw==}
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
-    resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
+  '@platforma-open/milaboratories.software-small-binaries@2.1.1':
+    resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
   '@platforma-sdk/block-tools@2.11.3':
     resolution: {integrity: sha512-YnFRtgRcXMLUv3T5v5C+80EMa5pdYlAFCfKCPCriVs3Mf/pYYnqWvqVhNOFR3DiV+NGYDZK4D92toPnbvzzsMA==}
@@ -1533,11 +1536,11 @@ packages:
   '@platforma-sdk/ui-vue@1.31.11':
     resolution: {integrity: sha512-G69XU6lLQ7D+J9pDmQHRKZb64WQMrI9m/bod32AuCgqrKZkFdiy5w6qkHDZH/pW0UBprUerZzH6GclRc1Q+Ohg==}
 
-  '@platforma-sdk/workflow-tengo@5.26.0':
-    resolution: {integrity: sha512-lXoFzD0LsQqEF9WUkA48avAY7LOK9WdP7sIc/Bymu1fOm4peXEWWZFW7fYckCPhHEAwcyzjqh7jdE8pVXrfzvw==}
-
   '@platforma-sdk/workflow-tengo@5.5.11':
     resolution: {integrity: sha512-qLzmBICKEsOOGg1Hh/yrTKw6OnKP7BPr/Ee4u5kYVSg0+4E4NZq9WFzs3wSgOL/7g3szbKrd7MKNPebqlSPYaA==}
+
+  '@platforma-sdk/workflow-tengo@6.6.5':
+    resolution: {integrity: sha512-BIY0DongPruQ7e2EMYy2b0UtO5ziGcLvr2RWgJ8ki17VKNzW3esm/RBszGHMrTYmXM0Yw7mCSasor4vH560g7A==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -7089,7 +7092,7 @@ snapshots:
       commander: 14.0.1
       selfsigned: 3.0.1
 
-  '@milaboratories/pframes-rs-wasip2@1.1.35': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.52': {}
 
   '@milaboratories/pl-client@2.16.1':
     dependencies:
@@ -7398,7 +7401,7 @@ snapshots:
 
   '@platforma-open/milaboratories.software-ptabler@1.13.3': {}
 
-  '@platforma-open/milaboratories.software-ptabler@1.16.1': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.3': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.0': {}
 
@@ -7417,6 +7420,8 @@ snapshots:
   '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7': {}
 
   '@platforma-open/milaboratories.software-small-binaries.java-stub@1.0.4': {}
+
+  '@platforma-open/milaboratories.software-small-binaries.line-counter@1.1.1': {}
 
   '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.1': {}
 
@@ -7453,10 +7458,11 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.small-asset': 1.1.4
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.1
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
+  '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     dependencies:
       '@platforma-open/milaboratories.software-small-binaries.hello-world': 1.1.7
       '@platforma-open/milaboratories.software-small-binaries.hello-world-py': 1.0.10
+      '@platforma-open/milaboratories.software-small-binaries.line-counter': 1.1.1
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
@@ -7596,20 +7602,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@platforma-sdk/workflow-tengo@5.26.0':
-    dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.35
-      '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 1.16.1
-      '@platforma-open/milaboratories.software-ptexter': 1.2.2
-      '@platforma-open/milaboratories.software-small-binaries': 2.0.4
-
   '@platforma-sdk/workflow-tengo@5.5.11':
     dependencies:
       '@milaboratories/software-pframes-conv': 2.2.9
       '@platforma-open/milaboratories.software-ptabler': 1.13.3
       '@platforma-open/milaboratories.software-ptexter': 1.2.0
       '@platforma-open/milaboratories.software-small-binaries': 1.15.23
+
+  '@platforma-sdk/workflow-tengo@6.6.5':
+    dependencies:
+      '@milaboratories/pframes-rs-wasip2': 1.1.52
+      '@milaboratories/software-pframes-conv': 2.2.9
+      '@platforma-open/milaboratories.software-ptabler': 2.1.3
+      '@platforma-open/milaboratories.software-ptexter': 1.2.2
+      '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@platforma-sdk/test': ^1.45.11
   '@milaboratories/graph-maker': 1.1.98
 
-  '@platforma-sdk/workflow-tengo': ^5.26.0
+  '@platforma-sdk/workflow-tengo': ^6.6.5
 
   '@platforma-open/milaboratories.software-small-binaries': ^1.15.19
   '@platforma-open/milaboratories.software-mixcr': 4.7.0-303-develop


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@platforma-sdk/workflow-tengo` from `^5.26.0` to `^6.6.5` across the workspace catalog and lock file, which is a major-version boundary jump (5.x → 6.x). Several transitive dependencies are also upgraded as a result.

- **`pnpm-workspace.yaml`**: The catalog entry for `@platforma-sdk/workflow-tengo` is updated to `^6.6.5`, affecting all workspace packages that consume it via `catalog:`.
- **`pnpm-lock.yaml`**: Lock file is regenerated to resolve the new `workflow-tengo@6.6.5`, pulling in `pframes-rs-wasip2@1.1.52`, `software-ptabler@2.1.3` (major bump), `software-small-binaries@2.1.1`, and the brand-new `software-small-binaries.line-counter@1.1.1` sub-package.
- **`.changeset/twelve-humans-kiss.md`**: Both `milaboratories.mixcr-shm-trees` and `milaboratories.mixcr-shm-trees.workflow` are classified as `minor` releases.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge assuming workflow compatibility has been tested; the jump from the 5.x to 6.x major version of workflow-tengo and the concurrent 1.x→2.x jump in software-ptabler are the main things worth verifying before shipping.

The change is purely a dependency version update with no application logic touched. The lockfile and workspace catalog are consistent, and the changeset is correctly scoped. The main thing to keep in mind is that workflow-tengo crosses a major-version boundary (5→6) and software-ptabler similarly crosses from 1.x to 2.x, so any breaking API changes in those packages would only surface at runtime or in workflow compilation — not from the diff alone.

pnpm-lock.yaml deserves a quick scan to confirm no unexpected package resolutions were introduced; everything else is straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Updates the pnpm catalog entry for @platforma-sdk/workflow-tengo from ^5.26.0 to ^6.6.5; all other catalog entries are untouched. |
| pnpm-lock.yaml | Lockfile regenerated to resolve workflow-tengo@6.6.5 and its updated transitive deps (pframes-rs-wasip2@1.1.52, software-ptabler@2.1.3, software-small-binaries@2.1.1 + new line-counter@1.1.1 sub-package); old 5.26.0 snapshot removed. |
| .changeset/twelve-humans-kiss.md | New changeset marking both mixcr-shm-trees packages as minor bumps; message simply describes the dependency upgrade. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    WS["pnpm-workspace.yaml catalog\n@platforma-sdk/workflow-tengo\n^5.26.0 → ^6.6.5"]

    subgraph OLD["Old resolution (5.26.0)"]
        O1["workflow-tengo@5.26.0"]
        O2["pframes-rs-wasip2@1.1.35"]
        O3["software-ptabler@1.16.1"]
        O4["software-small-binaries@2.0.4"]
        O1 --> O2
        O1 --> O3
        O1 --> O4
    end

    subgraph NEW["New resolution (6.6.5)"]
        N1["workflow-tengo@6.6.5"]
        N2["pframes-rs-wasip2@1.1.52"]
        N3["software-ptabler@2.1.3"]
        N4["software-small-binaries@2.1.1"]
        N5["software-small-binaries.line-counter@1.1.1 NEW"]
        N1 --> N2
        N1 --> N3
        N1 --> N4
        N4 --> N5
    end

    WS --> NEW
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    WS["pnpm-workspace.yaml catalog\n@platforma-sdk/workflow-tengo\n^5.26.0 → ^6.6.5"]

    subgraph OLD["Old resolution (5.26.0)"]
        O1["workflow-tengo@5.26.0"]
        O2["pframes-rs-wasip2@1.1.35"]
        O3["software-ptabler@1.16.1"]
        O4["software-small-binaries@2.0.4"]
        O1 --> O2
        O1 --> O3
        O1 --> O4
    end

    subgraph NEW["New resolution (6.6.5)"]
        N1["workflow-tengo@6.6.5"]
        N2["pframes-rs-wasip2@1.1.52"]
        N3["software-ptabler@2.1.3"]
        N4["software-small-binaries@2.1.1"]
        N5["software-small-binaries.line-counter@1.1.1 NEW"]
        N1 --> N2
        N1 --> N3
        N1 --> N4
        N4 --> N5
    end

    WS --> NEW
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Bump @platforma-sdk/workflow-tengo versi..."](https://github.com/platforma-open/mixcr-shm-trees/commit/7370922cf14d41f9f0346780e2b1fa8ca1e2e20c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42137783)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->