### PR TITLE
Update prepublishOnly script to align with latest block-tools

### DIFF
--- a/.changeset/many-cows-hang.md
+++ b/.changeset/many-cows-hang.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-shm-trees': patch
+---
+
+Update prepublishOnly script to align with latest block-tools

--- a/block/package.json
+++ b/block/package.json
@@ -5,7 +5,7 @@
     "pretty": "prettier --write \"./**/*.{js,jsx,mjs,cjs,ts,tsx,json,vue}\"",
     "build": "shx rm -rf ./block-pack && block-tools pack",
     "mark-stable": "block-tools mark-stable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
-    "prepublishOnly": "block-tools pack && block-tools publish -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'"
+    "prepublishOnly": "block-tools pack && block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science"
   },
   "files": [
     "index.d.ts",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `prepublishOnly` script in `block/package.json` to align with the latest `block-tools` API, adding the required `--registry-serve-url` argument to `block-tools publish`. A patch-level changeset is included.

- **`prepublishOnly` script** (`block/package.json`): `block-tools publish` now receives a `--registry-serve-url` argument pointing to the public-facing block registry. The single quotes previously wrapping the `-r` S3 URL were also removed, creating a minor inconsistency with the still-quoted `mark-stable` script.
- **Changeset** (`.changeset/many-cows-hang.md`): Registers a `patch` bump for `@platforma-open/milaboratories.mixcr-shm-trees` to version the script change.

**Touched terms:**

| Term | Definition | Change |
|---|---|---|
| `prepublishOnly` | npm lifecycle hook executed automatically before `npm publish` | Updated to pass `--registry-serve-url` to `block-tools publish` and unquoted the `-r` S3 URL |
| `block-tools publish` | CLI subcommand that packages and pushes a block to the S3 registry | Now accepts `--registry-serve-url` to specify the public serve base URL |
| `--registry-serve-url` | New `block-tools publish` flag pointing to the public HTTP registry endpoint | Added, set to `https://blocks.pl-open.science` |
| changeset | Versioning artifact consumed by Changesets tooling to produce a release | New patch-level entry `many-cows-hang.md` added for this change |

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the functional change adds --registry-serve-url which aligns the script with the latest block-tools interface.

The core change is straightforward and intentional. The only notable issue is that single quotes around the S3 URL were dropped in prepublishOnly while the identical URL in mark-stable remains quoted, leaving a shell wildcard character unguarded in an edge case. This is unlikely to cause real failures in practice.

block/package.json — the unquoted S3 URL is worth a second look for consistency with mark-stable
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| block/package.json | prepublishOnly script updated: adds --registry-serve-url to block-tools publish, and removes single quotes around the S3 -r URL (inconsistent with mark-stable) |
| .changeset/many-cows-hang.md | New patch-level changeset for @platforma-open/milaboratories.mixcr-shm-trees documenting the prepublishOnly script update |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([npm publish]) --> B[prepublishOnly hook fires]
    B --> C[block-tools pack]
    C --> D{Pack successful?}
    D -- No --> E([Abort])
    D -- Yes --> F["block-tools publish -r S3_URL --registry-serve-url https://blocks.pl-open.science"]
    F --> G([Block published to S3 + served at blocks.pl-open.science])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([npm publish]) --> B[prepublishOnly hook fires]
    B --> C[block-tools pack]
    C --> D{Pack successful?}
    D -- No --> E([Abort])
    D -- Yes --> F["block-tools publish -r S3_URL --registry-serve-url https://blocks.pl-open.science"]
    F --> G([Block published to S3 + served at blocks.pl-open.science])
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ablock%2Fpackage.json%3A8%0AThe%20%60-r%60%20URL%20in%20%60prepublishOnly%60%20is%20now%20unquoted%2C%20while%20the%20identical%20URL%20in%20%60mark-stable%60%20is%20still%20wrapped%20in%20single%20quotes.%20The%20%60%3F%60%20in%20%60%3Fregion%3Deu-central-1%60%20is%20a%20shell%20wildcard%20character%3B%20although%20most%20shells%20won't%20glob-expand%20it%20because%20%60s3%3A%2F%2F%60%20is%20not%20a%20filesystem%20path%2C%20removing%20quotes%20creates%20an%20inconsistency%20with%20the%20rest%20of%20the%20scripts%20and%20introduces%20an%20unnecessary%20fragility%20if%20the%20shell%20environment%20differs.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22prepublishOnly%22%3A%20%22block-tools%20pack%20%26%26%20block-tools%20publish%20-r%20's3%3A%2F%2Fmilab-euce1-prod-pkgs-s3-block-registry%2Fpub%2Freleases%2F%3Fregion%3Deu-central-1'%20--registry-serve-url%20https%3A%2F%2Fblocks.pl-open.science%22%0A%60%60%60%0A%0A&repo=platforma-open%2Fmixcr-shm-trees&pr=120&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
block/package.json:8
The `-r` URL in `prepublishOnly` is now unquoted, while the identical URL in `mark-stable` is still wrapped in single quotes. The `?` in `?region=eu-central-1` is a shell wildcard character; although most shells won't glob-expand it because `s3://` is not a filesystem path, removing quotes creates an inconsistency with the rest of the scripts and introduces an unnecessary fragility if the shell environment differs.

```suggestion
    "prepublishOnly": "block-tools pack && block-tools publish -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1' --registry-serve-url https://blocks.pl-open.science"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update prepublishOnly script to align wi..."](https://github.com/platforma-open/mixcr-shm-trees/commit/867b4750a817e2972fb4c6c12923eec2388f78cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43625750)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->