### PR TITLE
Fix Double -> Long conversion after Parquet migration

### DIFF
--- a/.changeset/soft-ghosts-shake.md
+++ b/.changeset/soft-ghosts-shake.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.mixcr-shm-trees.workflow': minor
+'@platforma-open/milaboratories.mixcr-shm-trees': minor
+---
+
+Fix Double -> Long conversion after Parquet migration

--- a/workflow/src/export-settings.lib.tengo
+++ b/workflow/src/export-settings.lib.tengo
@@ -21,6 +21,18 @@ addTableAnnotations := func(order, defaultVisibility, label, specAnnotations) {
 	})
 }
 
+// These columns reach importFileParquet float-formatted ("192.0"); its strict
+// String->Long cast then nulls the whole column, and an all-null parentId makes
+// the tree viewer show "multiple roots". Strip the fractional part before the
+// cast to coerce them back to Long. Two independent causes converge here:
+//   - parentId: MiXCR emits a clean integer, but the Pandas-based ptransform
+//     aggregation (tables-aggregation.lib.tengo) promotes any NA-bearing integer
+//     column to float, and tree roots have an empty parent.
+//   - readCount / totalReadsCountInTree: MiXCR emits these as doubles itself.
+// This truncates; it is not mixcr-clonotyping's numeric round().cast (that needs
+// a pt step). Equivalent only because every value here is integer-valued (X.0).
+stripDecimal := [{ type: `regexpReplace`, pattern: `^(\d+)\.\d+$`, replacement: `$1` }]
+
 // export of threes whithout nodes
 shmTree := func(dataDescription) {
     axes := []
@@ -107,6 +119,7 @@ shmTree := func(dataDescription) {
         column: "totalReadsCountInTree",
         id: "total-reads-count-in-tree",
         allowNA: allowNA,
+        preProcess: stripDecimal,
         spec: {
             name: "pl7.app/vdj/totalReadsCountInTree",
             valueType: "Long",
@@ -318,6 +331,7 @@ shmTreeNodes := func(dataDescription) {
         column: "parentId",
         id: "parent-id",
         allowNA: true,
+        preProcess: stripDecimal,
         spec: {
             name: "pl7.app/dendrogram/topology",
             valueType: "Long",
@@ -783,6 +797,7 @@ shmTreeNodesWithClones := func(dataDescription, donorColumn) {
         column: "readCount",
         id: "read-count",
         allowNA: true,
+        preProcess: stripDecimal,
         spec: {
           name: "pl7.app/vdj/readCount",
           valueType: "Long",
@@ -901,6 +916,7 @@ shmTreeNodesUniqueIsotype := func(dataDescription) {
         column: "readCount",
         id: "read-count",
         allowNA: true,
+        preProcess: stripDecimal,
         spec: {
           name: "pl7.app/vdj/readCount",
           valueType: "Long",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR patches a data-corruption regression introduced by the Parquet migration: integer columns (`parentId`, `readCount`, `totalReadsCountInTree`) were arriving at `importFileParquet` as float-formatted strings (e.g. `\"192.0\"`), causing its strict String→Long cast to null the entire column and making the tree viewer display \"multiple roots\".

- Introduces the shared `stripDecimal` preprocessing rule — a single `regexpReplace` that strips `.0` suffixes before the Long cast — and applies it to the four affected column definitions across all four exporter functions.
- The root causes are identified in the comment: Pandas promotes any NA-bearing integer column to float (affects `parentId`), while MiXCR itself emits `readCount`/`totalReadsCountInTree` as doubles.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The fix is targeted and well-explained; the four patched columns are the ones confirmed to arrive as float-formatted strings after Parquet migration.

The stripDecimal regex only handles decimal notation and silently passes through scientific-notation strings unchanged. Additionally, the comment's own statement that Pandas promotes any NA-bearing integer column to float raises the question of whether other Long columns in the same tables are equally broken but not yet fixed. Both are speculative rather than confirmed regressions.

workflow/src/export-settings.lib.tengo — verify whether the other NA-bearing Long columns need the same preProcess step, and whether scientific-notation output is possible for any of the patched columns.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/export-settings.lib.tengo | Adds `stripDecimal` regex preProcess to `totalReadsCountInTree`, `parentId`, `readCount` (x2) to fix null Long columns after Parquet migration; other NA-bearing Long columns may need the same treatment. |
| .changeset/soft-ghosts-shake.md | New changeset entry bumping both workflow and root packages as `minor` for the Parquet double-to-Long fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant MiXCR
    participant Pandas as Pandas aggregation
    participant Parquet as importFileParquet
    participant Viewer as Tree Viewer

    MiXCR->>Pandas: readCount/totalReadsCountInTree as Double
    MiXCR->>Pandas: parentId as Integer, NA for tree roots
    Pandas->>Parquet: Float-formatted strings (192.0)
    Note over Parquet: strict String->Long cast fails -> null
    Parquet-->>Viewer: all-null parentId / readCount
    Viewer-->>Viewer: multiple roots error

    Note over Parquet: After this PR
    Pandas->>Parquet: Float-formatted strings (192.0)
    Note over Parquet: stripDecimal: 192.0 -> 192
    Parquet->>Viewer: Long values (192, 5...)
    Viewer->>Viewer: correct tree topology
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant MiXCR
    participant Pandas as Pandas aggregation
    participant Parquet as importFileParquet
    participant Viewer as Tree Viewer

    MiXCR->>Pandas: readCount/totalReadsCountInTree as Double
    MiXCR->>Pandas: parentId as Integer, NA for tree roots
    Pandas->>Parquet: Float-formatted strings (192.0)
    Note over Parquet: strict String->Long cast fails -> null
    Parquet-->>Viewer: all-null parentId / readCount
    Viewer-->>Viewer: multiple roots error

    Note over Parquet: After this PR
    Pandas->>Parquet: Float-formatted strings (192.0)
    Note over Parquet: stripDecimal: 192.0 -> 192
    Parquet->>Viewer: Long values (192, 5...)
    Viewer->>Viewer: correct tree topology
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aworkflow%2Fsrc%2Fexport-settings.lib.tengo%3A34%0A**Regex%20doesn't%20handle%20scientific%20notation**%0A%0AThe%20pattern%20%60%5E%28%5Cd%2B%29%5C.%5Cd%2B%24%60%20only%20matches%20decimal-point%20notation%20%28e.g.%20%22192.0%22%29.%20Pandas%2FNumPy%20can%20switch%20to%20scientific%20notation%20for%20large%20counts%20%28e.g.%20%221.5e%2B09%22%29%20when%20the%20value%20exceeds%20a%20display%20threshold.%20If%20that%20happens%2C%20the%20regex%20silently%20fails%20to%20strip%20the%20decimal%2C%20the%20downstream%20strict%20String%E2%86%92Long%20cast%20receives%20an%20unmodified%20scientific-notation%20string%2C%20and%20the%20entire%20column%20is%20nulled%20%E2%80%94%20the%20same%20root%20problem%20this%20PR%20is%20fixing.%20Read%20counts%20and%20tree-level%20counts%20are%20typically%20small%20enough%20that%20this%20is%20unlikely%20in%20practice%2C%20but%20it's%20worth%20validating%20that%20no%20real-world%20dataset%20can%20produce%20scientific-notation%20output%20from%20the%20Pandas%20aggregation%20step.%0A%0A%23%23%23%20Issue%202%20of%202%0Aworkflow%2Fsrc%2Fexport-settings.lib.tengo%3A500-562%0A**Other%20NA-bearing%20Long%20columns%20in%20the%20same%20table%20may%20also%20need%20%60stripDecimal%60**%0A%0AThe%20block-level%20comment%20states%3A%20*%22the%20Pandas-based%20ptransform%20aggregation%20%28tables-aggregation.lib.tengo%29%20promotes%20**any**%20NA-bearing%20integer%20column%20to%20float.%22*%20If%20that%20rule%20is%20unconditional%2C%20then%20every%20Long%20column%20with%20%60allowNA%3A%20true%2FallowNA%60%20that%20passes%20through%20the%20same%20aggregation%20step%20is%20potentially%20affected%20%E2%80%94%20not%20just%20%60parentId%60.%20In%20%60shmTreeNodes%60%20the%20four%20mutation-count%20columns%20%28%60nMutationCount*BasedOnMrca%60%2C%20%60aaMutationCount*BasedOnMrca%60%2C%20%60nMutationCount*BasedOnGermline%60%2C%20%60aaMutationCount*BasedOnGermline%60%29%20are%20all%20typed%20%60Long%60%20with%20%60allowNA%3A%20allowNA%60.%20Similarly%2C%20%60totalUniqueCellCountInTree%60%2C%20%60totalUniqueMoleculeCountInTree%60%2C%20%60numberOfClonesInTree%60%2C%20and%20%60numberOfNodesWithClones%60%20in%20%60shmTree%60%20share%20the%20same%20profile.%20If%20those%20columns%20flow%20through%20the%20same%20aggregation%2C%20they%20would%20be%20silently%20nulled%20too.%20Can%20you%20confirm%20they%20do%20not%20go%20through%20the%20Pandas%20aggregation%20path%20%28or%20that%20they%20never%20carry%20NAs%20in%20practice%29%3F%0A%0A&repo=platforma-open%2Fmixcr-shm-trees&pr=121&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
workflow/src/export-settings.lib.tengo:34
**Regex doesn't handle scientific notation**

The pattern `^(\d+)\.\d+$` only matches decimal-point notation (e.g. "192.0"). Pandas/NumPy can switch to scientific notation for large counts (e.g. "1.5e+09") when the value exceeds a display threshold. If that happens, the regex silently fails to strip the decimal, the downstream strict String→Long cast receives an unmodified scientific-notation string, and the entire column is nulled — the same root problem this PR is fixing. Read counts and tree-level counts are typically small enough that this is unlikely in practice, but it's worth validating that no real-world dataset can produce scientific-notation output from the Pandas aggregation step.

### Issue 2 of 2
workflow/src/export-settings.lib.tengo:500-562
**Other NA-bearing Long columns in the same table may also need `stripDecimal`**

The block-level comment states: *"the Pandas-based ptransform aggregation (tables-aggregation.lib.tengo) promotes **any** NA-bearing integer column to float."* If that rule is unconditional, then every Long column with `allowNA: true/allowNA` that passes through the same aggregation step is potentially affected — not just `parentId`. In `shmTreeNodes` the four mutation-count columns (`nMutationCount*BasedOnMrca`, `aaMutationCount*BasedOnMrca`, `nMutationCount*BasedOnGermline`, `aaMutationCount*BasedOnGermline`) are all typed `Long` with `allowNA: allowNA`. Similarly, `totalUniqueCellCountInTree`, `totalUniqueMoleculeCountInTree`, `numberOfClonesInTree`, and `numberOfNodesWithClones` in `shmTree` share the same profile. If those columns flow through the same aggregation, they would be silently nulled too. Can you confirm they do not go through the Pandas aggregation path (or that they never carry NAs in practice)?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Double -&gt; Long conversion after Parq..."](https://github.com/platforma-open/mixcr-shm-trees/commit/e859e786d468009be810330cdaaeee038b06a77e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43644954)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->