### PR TITLE
Fix Double -> Long conversion after Parquet migration

### DIFF
--- a/.changeset/soft-ghosts-shake.md
+++ b/.changeset/soft-ghosts-shake.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.mixcr-shm-trees.workflow': minor
+'@platforma-open/milaboratories.mixcr-shm-trees': minor
+---
+
+Fix Double -> Long conversion after Parquet migration

--- a/workflow/src/export-settings.lib.tengo
+++ b/workflow/src/export-settings.lib.tengo
@@ -21,6 +21,43 @@ addTableAnnotations := func(order, defaultVisibility, label, specAnnotations) {
 	})
 }
 
+// importFileParquet reads every column as String and strict-casts to the declared
+// type, nulling any value that isn't clean for that type. Integer columns can
+// arrive float-formatted ("192.0") from two sources, so coerce EVERY Long/Int
+// column and axis back to integer by stripping a trailing decimal before the cast:
+//   - the Pandas-based ptransform aggregation (tables-aggregation.lib.tengo)
+//     promotes any NA-bearing integer column to float, and which columns it hits
+//     is data-dependent per partition (parentId always; cloneId / uniqueMoleculeCount
+//     in some samples but not others) — so a hand-picked column list is not enough;
+//   - MiXCR emits readCount / totalReadsCountInTree as doubles outright.
+// Truncates rather than round()-casting (mixcr-clonotyping's approach, which needs a
+// pt step) — equivalent here because these are whole-number ids/counts.
+stripDecimal := [{ type: `regexpReplace`, pattern: `^(-?\d+)\.\d+$`, replacement: `$1` }]
+
+// Append stripDecimal to every Long/Int column and axis. No-op on clean integers;
+// Doubles/Strings are left untouched; an existing preProcess (e.g. the fileName
+// extractor) is preserved. Call on each function's axes/columns before returning.
+stripDecimalOnIntColumns := func(axes, columns) {
+	for i, ax in axes {
+		if !is_undefined(ax.spec) && (ax.spec.type == "Long" || ax.spec.type == "Int") {
+			base := []
+			if !is_undefined(ax.preProcess) {
+				base = ax.preProcess
+			}
+			axes[i].preProcess = append(base, stripDecimal...)
+		}
+	}
+	for i, col in columns {
+		if !is_undefined(col.spec) && (col.spec.valueType == "Long" || col.spec.valueType == "Int") {
+			base := []
+			if !is_undefined(col.preProcess) {
+				base = col.preProcess
+			}
+			columns[i].preProcess = append(base, stripDecimal...)
+		}
+	}
+}
+
 // export of threes whithout nodes
 shmTree := func(dataDescription) {
     axes := []
@@ -247,6 +284,7 @@ shmTree := func(dataDescription) {
         }
     })
 
+	stripDecimalOnIntColumns(axes, columns)
 	return {
         pfconvParams: {
             axes: axes,
@@ -665,6 +703,7 @@ shmTreeNodes := func(dataDescription) {
         }
     })
 
+	stripDecimalOnIntColumns(axes, columns)
 	return {
         pfconvParams: {
             axes: axes,
@@ -852,6 +891,7 @@ shmTreeNodesWithClones := func(dataDescription, donorColumn) {
         }
     })
 
+	stripDecimalOnIntColumns(axes, columns)
 	return {
         pfconvParams: {
             axes: axes,
@@ -921,6 +961,7 @@ shmTreeNodesUniqueIsotype := func(dataDescription) {
         }
     })
 
+	stripDecimalOnIntColumns(axes, columns)
 	return {
         pfconvParams: {
             axes: axes,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a type-conversion regression introduced by the Parquet migration, where integer columns (`Long`/`Int`) arrive float-formatted (e.g., `"192.0"`) — either because Pandas promotes NA-bearing integer columns to float or because MiXCR emits certain counts as doubles. A module-level `stripDecimal` regex step and a `stripDecimalOnIntColumns` helper are added; the helper is called in all four export functions (`shmTree`, `shmTreeNodes`, `shmTreeNodesWithClones`, `shmTreeNodesUniqueIsotype`) before their `pfconvParams` is returned.

- **`stripDecimal`** — new module-level constant: a single-element `preProcess` array containing a `regexpReplace` that strips a trailing `.digits` suffix (e.g., `"192.0"` → `"192"`), making the value safe for the subsequent strict-cast to `Long`/`Int`.
- **`stripDecimalOnIntColumns`** — new helper function that iterates all axes (`spec.type`) and columns (`spec.valueType`) and appends `stripDecimal` to any `Long`/`Int` entry's `preProcess`, preserving any pre-existing steps.
- All four export functions now call `stripDecimalOnIntColumns(axes, columns)` immediately before their `return` statement, ensuring every `Long`/`Int` field across all table shapes is covered without a fragile hand-picked column list.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix is well-scoped and all four export functions are updated consistently.

The logic change is small and correct — the regex handles the described float-formatted-integer cases and is a no-op for already-clean integers. All four export functions are covered. The only note is a changeset version bump (minor vs patch) that has no runtime impact but affects release semantics.

.changeset/soft-ghosts-shake.md — version type may want a second look before the release is cut.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/soft-ghosts-shake.md | Changeset entry classifying the fix as `minor` — conventionally a `patch` for a bug fix, but may be intentional given the data-behaviour change introduced by the Parquet migration. |
| workflow/src/export-settings.lib.tengo | Adds `stripDecimal` regex step and `stripDecimalOnIntColumns` helper; correctly wired into all four export functions (shmTree, shmTreeNodes, shmTreeNodesWithClones, shmTreeNodesUniqueIsotype) before their return statements. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Export function called\n(shmTree / shmTreeNodes /\nshmTreeNodesWithClones /\nshmTreeNodesUniqueIsotype)"] --> B["Build axes[] and columns[]\nwith Long/Int specs"]
    B --> C["stripDecimalOnIntColumns(axes, columns)"]
    C --> D{"For each axis:\nspec.type == Long or Int?"}
    D -- Yes --> E["Append stripDecimal\nregexpReplace to axis.preProcess\ne.g. '192.0' → '192'"]
    D -- No --> F["Leave axis unchanged"]
    E --> G{"For each column:\nspec.valueType == Long or Int?"}
    F --> G
    G -- Yes --> H["Append stripDecimal\nregexpReplace to col.preProcess\ne.g. '99.0' → '99'"]
    G -- No --> I["Leave column unchanged"]
    H --> J["Return pfconvParams\nwith patched axes + columns"]
    I --> J
    J --> K["xsv.importFileMap reads Parquet\nString → stripDecimal → strict-cast Long/Int"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Export function called\n(shmTree / shmTreeNodes /\nshmTreeNodesWithClones /\nshmTreeNodesUniqueIsotype)"] --> B["Build axes[] and columns[]\nwith Long/Int specs"]
    B --> C["stripDecimalOnIntColumns(axes, columns)"]
    C --> D{"For each axis:\nspec.type == Long or Int?"}
    D -- Yes --> E["Append stripDecimal\nregexpReplace to axis.preProcess\ne.g. '192.0' → '192'"]
    D -- No --> F["Leave axis unchanged"]
    E --> G{"For each column:\nspec.valueType == Long or Int?"}
    F --> G
    G -- Yes --> H["Append stripDecimal\nregexpReplace to col.preProcess\ne.g. '99.0' → '99'"]
    G -- No --> I["Leave column unchanged"]
    H --> J["Return pfconvParams\nwith patched axes + columns"]
    I --> J
    J --> K["xsv.importFileMap reads Parquet\nString → stripDecimal → strict-cast Long/Int"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.changeset%2Fsoft-ghosts-shake.md%3A2-3%0AChangeset%20version%20type%20is%20%60minor%60%20for%20what%20the%20title%20and%20description%20call%20a%20bug%20fix.%20Semver%20convention%20is%20%60patch%60%20for%20a%20fix%20that%20doesn't%20add%20or%20change%20public%20API%20surface.%20Using%20%60minor%60%20here%20will%20bump%20the%20minor%20version%20of%20both%20packages%20unnecessarily.%20If%20the%20intention%20is%20simply%20to%20fix%20the%20Double%E2%86%92Long%20conversion%20regression%2C%20consider%20downgrading%20to%20%60patch%60.%0A%0A%60%60%60suggestion%0A'%40platforma-open%2Fmilaboratories.mixcr-shm-trees.workflow'%3A%20patch%0A'%40platforma-open%2Fmilaboratories.mixcr-shm-trees'%3A%20patch%0A%60%60%60%0A%0A&repo=platforma-open%2Fmixcr-shm-trees&pr=122&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/soft-ghosts-shake.md:2-3
Changeset version type is `minor` for what the title and description call a bug fix. Semver convention is `patch` for a fix that doesn't add or change public API surface. Using `minor` here will bump the minor version of both packages unnecessarily. If the intention is simply to fix the Double→Long conversion regression, consider downgrading to `patch`.

```suggestion
'@platforma-open/milaboratories.mixcr-shm-trees.workflow': patch
'@platforma-open/milaboratories.mixcr-shm-trees': patch
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Double -&gt; Long conversion after Parq..."](https://github.com/platforma-open/mixcr-shm-trees/commit/0aaabe8777a2e44b29ba56e8d9ac0c9df675cb6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43650817)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->