### PR TITLE
Migrate to ptabler

### DIFF
--- a/.changeset/blue-shirts-kneel.md
+++ b/.changeset/blue-shirts-kneel.md
@@ -1,0 +1,13 @@
+---
+'@platforma-open/milaboratories.mixcr-shm-trees.workflow': minor
+'@platforma-open/milaboratories.mixcr-shm-trees': minor
+---
+
+Replace ptransform with ptabler for all table aggregation
+
+The by-nodes deduplication and the sequence-of-interest per-tree
+aggregation now run in-process via ptabler instead of shelling out to
+the ptransform binary. Integer columns are coerced back to their
+declared types after the TSV read, so they are no longer float-promoted
+(e.g. `192` -> `192.0`) and nulled by the Parquet importer. The
+software-ptransform dependency is removed.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "//": {
     "pnpm": {
       "overrides": {
-        "@platforma-open/milaboratories.software-ptransform": "file:/Users/dbolotin/milab/blocks/software-ptransform/package.tgz",
         "@milaboratories/graph-maker": "/Users/poslavskysv/Projects/milab/platforma/graph-maker/milaboratories-graph-maker-1.1.0.tgz",
         "@platforma-sdk/model": "file:/Users/dbolotin/milab/core/platforma/sdk/model/package.tgz",
         "@platforma-sdk/workflow-tengo": "file:/Users/poslavskysv/Projects/milab/platforma/platforma-sdk/sdk/workflow-tengo/package.tgz",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ catalogs:
     '@platforma-open/milaboratories.software-mixcr':
       specifier: 4.7.0-303-develop
       version: 4.7.0-303-develop
-    '@platforma-open/milaboratories.software-ptransform':
-      specifier: ^1.6.6
-      version: 1.6.6
     '@platforma-sdk/block-tools':
       specifier: 2.12.4
       version: 2.12.4
@@ -247,9 +244,6 @@ importers:
       '@platforma-open/milaboratories.software-mixcr':
         specifier: 'catalog:'
         version: 4.7.0-303-develop
-      '@platforma-open/milaboratories.software-ptransform':
-        specifier: 'catalog:'
-        version: 1.6.6
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
         version: 4.0.10
@@ -1458,9 +1452,6 @@ packages:
 
   '@platforma-open/milaboratories.software-ptexter@1.2.3':
     resolution: {integrity: sha512-5wwzvPko/tjkm6EnirsnjB+MO5mF//tgJplI+jPh3bcSHpEdHF+B9xg+S1owAnekqbimMrFZWqHSVY9ZmIHOjw==}
-
-  '@platforma-open/milaboratories.software-ptransform@1.6.6':
-    resolution: {integrity: sha512-J43RsEiEo98Hwb+ze1UO42gXa3VTDCqMdBLbkTZiEs5nOtnqetMKfFRcGcSn/uHlUAdkBLAQ6WmEtEIfAgaUcA==}
 
   '@platforma-open/milaboratories.software-small-binaries.guided-command@1.1.1':
     resolution: {integrity: sha512-UPhSOP43GAL+gQVPlE/2ymjuOiYVojhmDad1moS4SI+t6IDF9QgnAj5I7V8eP2P2x0oSY5apgjg4EeUiGBrIkw==}
@@ -7600,8 +7591,6 @@ snapshots:
   '@platforma-open/milaboratories.software-ptexter@1.2.0': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.3': {}
-
-  '@platforma-open/milaboratories.software-ptransform@1.6.6': {}
 
   '@platforma-open/milaboratories.software-small-binaries.guided-command@1.1.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,6 @@ catalog:
   '@platforma-open/milaboratories.software-small-binaries': ^1.15.19
   '@platforma-open/milaboratories.software-mixcr': 4.7.0-303-develop
   '@platforma-open/milaboratories.software-mitool': 2.3.1-24-main
-  '@platforma-open/milaboratories.software-ptransform': ^1.6.6
 
   '@milaboratories/helpers': ^1.12.0
 

--- a/workflow/package.json
+++ b/workflow/package.json
@@ -17,7 +17,6 @@
     "@platforma-sdk/tengo-builder": "catalog:",
     "@platforma-open/milaboratories.software-mixcr": "catalog:",
     "@platforma-open/milaboratories.software-mitool": "catalog:",
-    "@platforma-open/milaboratories.software-ptransform": "catalog:",
     "@platforma-sdk/test": "catalog:",
     "vitest": "catalog:",
     "typescript": "catalog:"

--- a/workflow/src/soi.tpl.tengo
+++ b/workflow/src/soi.tpl.tengo
@@ -7,12 +7,12 @@ xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 json := import("json")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
 soiExport := import(":soi-export")
+tablesAgg := import(":tables-aggregation")
 
 self.defineOutputs("nodesResult", "treesResult")
 
 // import MiXCR as a software to use
 mitoolSw := assets.importSoftware("@platforma-open/milaboratories.software-mitool:main")
-paggregateSw := assets.importSoftware("@platforma-open/milaboratories.software-ptransform:main")
 
 inferPartitionKeyLength := func(data) {
 	rType := data.info().Type.Name
@@ -46,7 +46,6 @@ self.body(func(inputs) {
 	modifiedAxesSpecs := []
 	importAxesSpec := []
 
-	aggregationGroupByTargets := []
 	aggregationImportAxesSpec := []
 
 	for idx, spec in originalAxesSpecs {
@@ -62,7 +61,6 @@ self.body(func(inputs) {
 
 		// aggregating clonal and subtree axes away
 		if spec.name != "pl7.app/dendrogram/subtreeId" && spec.name != "pl7.app/dendrogram/nodeId" {
-			aggregationGroupByTargets = append(aggregationGroupByTargets, colName)
 			aggregationImportAxesSpec = append(aggregationImportAxesSpec, {
 				column: colName,
 				spec: spec
@@ -161,32 +159,14 @@ self.body(func(inputs) {
 		partitionKeyLength: 0 // inferPartitionKeyLength(queryData)
 	}
 
-	aggregations := []
-	for col in resultColumns {
-		aggregations = append(aggregations, {
-			type: "first",
-			src: col.column,
-			dst: col.column
-		})
-	}
-
-	aggregationWorkflow := { steps: [ {
-			type: "aggregate",
-			groupBy: aggregationGroupByTargets,
-			aggregations: aggregations
-		} ] }
-
-	aggregateCmd := exec.builder().
-        printErrStreamToStdout().
-        software(paggregateSw).
-        arg("--workflow").arg("wf.json").
-		writeFile("wf.json", json.encode(aggregationWorkflow)).
-		arg("input.tsv").addFile("input.tsv", resultCsv).
-		arg("output.tsv").saveFile("output.tsv").
-        env("CIDADHOC", "1234").
-		run()
-
-	aggregatedCsv := aggregateCmd.getFile("output.tsv")
+	// Collapse subtree/node rows to one row per tree (first per group), reusing the
+	// ptabler dedup helper so integer columns are coerced back from the all-String
+	// read instead of being float-promoted by ptransform.
+	aggregatedCsv := tablesAgg.ensureUniqueness(
+		resultCsv,
+		tablesAgg.ensureUniquenessParamsFromPconvParams(aggregatedConvParams),
+		"first"
+	)
 
 	nodesResult := xsv.importFile(
         resultCsv,

--- a/workflow/src/tables-aggregation.lib.tengo
+++ b/workflow/src/tables-aggregation.lib.tengo
@@ -1,82 +1,65 @@
 ll := import("@platforma-sdk/workflow-tengo:ll")
-exec := import("@platforma-sdk/workflow-tengo:exec")
-assets := import("@platforma-sdk/workflow-tengo:assets")
+pt := import("@platforma-sdk/workflow-tengo:pt")
 slices := import("@platforma-sdk/workflow-tengo:slices")
-json := import("json")
 
-paggregateSw := assets.importSoftware("@platforma-open/milaboratories.software-ptransform:main")
-
+// Column name + declared type for every axis and value column, so ensureUniqueness
+// knows which columns to coerce back to an integer type after reading the
+// intermediate TSV as all-String.
 ensureUniquenessParamsFromPconvParams := func(pfConvParams) {
     return {
         axes: slices.map(pfConvParams.axes, func(axis) {
-            return axis.column
+            return { column: axis.column, type: axis.spec.type }
         }),
         columns: slices.map(pfConvParams.columns, func(col) {
-            return col.column
+            return { column: col.column, type: col.spec.valueType }
         })
     }
 }
 
-/** Aggregating by-nodes output to make it uniquely addressable by it's native key */
+/** Aggregating by-nodes output to make it uniquely addressable by its native key. */
 ensureUniqueness := func(inputTsv, params, ...aggParams) {
-    keyColumns := params.axes
-    pickCols := params.columns
-
-    aggregationWorkflow := undefined
-    if len(aggParams) > 1 {
-        pickCols := []
-        for col in pickCols {
-            pickCols = append(pickCols, [
-                col,
-                col
-                ]
-            )
-        }
-
-        rankingCol := aggParams[1]
-        aggregationWorkflow = {
-            steps: [ {
-                type: "aggregate",
-                groupBy: keyColumns,
-                aggregations: [ {
-                    type: aggParams[0],
-                    rankingCol: rankingCol,
-                    pickCols: pickCols
-                } ]
-            } ]
-        }
-    } else {
-        aggregations := []
-        for col in pickCols {
-            aggregations = append(aggregations, {
-                type: aggParams[0],
-                src: col,
-                dst: col
-            })
-        }
-
-        aggregationWorkflow = { steps: [ {
-                type: "aggregate",
-                groupBy: keyColumns,
-                aggregations: aggregations
-            } ]
-        }
+    allCols := []
+    for axis in params.axes {
+        allCols = append(allCols, axis)
+    }
+    for col in params.columns {
+        allCols = append(allCols, col)
     }
 
-    aggregateCmd := exec.builder().
-        printErrStreamToStdout().
-        software(paggregateSw).
-        arg("--workflow").arg("wf.json").
-        writeFile("wf.json", json.encode(aggregationWorkflow)).
-        arg("input.tsv").addFile("input.tsv", inputTsv).
-        arg("output.tsv").saveFile("output.tsv").
-        env("CIDADHOC", "1234").
-        run()
+    keyNames := slices.map(params.axes, func(axis) { return axis.column })
 
-    return aggregateCmd.getFile("output.tsv")
+    wf := pt.workflow()
+
+    df := wf.frame({ file: inputTsv, xsvType: "tsv" }, { inferSchema: false })
+
+    intCasts := []
+    for c in allCols {
+        if c.type == "Long" || c.type == "Int" {
+            intCasts = append(intCasts, pt.col(c.column).cast("Double").round().cast(c.type).alias(c.column))
+        }
+    }
+    if len(intCasts) > 0 {
+        df = df.withColumns(intCasts...)
+    }
+
+    result := undefined
+    if len(aggParams) > 1 {
+        // max_by: keep, per key, the row with the greatest ranking column value.
+        rankCol := aggParams[1]
+        aggs := slices.map(params.columns, func(col) {
+            return pt.col(col.column).maxBy(pt.col(rankCol)).alias(col.column)
+        })
+        result = df.groupBy(keyNames...).agg(aggs...)
+    } else {
+        // first: dedup rows by key, keeping the first.
+        result = df.unique({ subset: keyNames, keep: "first", maintainOrder: true })
+    }
+
+    result.save("output.tsv")
+    return wf.run().getFile("output.tsv")
 }
 
 export ll.toStrict({
-	ensureUniqueness: ensureUniqueness,
+    ensureUniqueness: ensureUniqueness,
     ensureUniquenessParamsFromPconvParams: ensureUniquenessParamsFromPconvParams
 })


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the external `paggregateSw` binary (ptransform) with the `pt` (ptabler) library for the TSV deduplication step in `ensureUniqueness`, and extends `ensureUniquenessParamsFromPconvParams` to carry column type metadata so that integer columns are correctly re-coerced after reading the TSV with `inferSchema: false`.

**Touched Terms:**

- **`ensureUniqueness`** — Deduplicates a multi-sample TSV by key axes. Now implemented as an in-process ptabler DataFrame workflow instead of shelling out to a separate ptransform binary; integer columns (Long/Int) are explicitly re-cast via `cast(\"Double\") → round() → cast(type)` before dedup.
- **`ensureUniquenessParamsFromPconvParams`** — Converts pfconv export parameters into the shape expected by `ensureUniqueness`. Previously extracted only `column` names; now also extracts `type` (`axis.spec.type`) and `valueType` (`col.spec.valueType`) so `ensureUniqueness` can apply type-correct casts.
- **`aggParams`** — Variadic arguments controlling deduplication strategy: `aggParams[0]` was the aggregation-type string (\"max_by\" / \"first\"), `aggParams[1]` was the ranking column for max_by. In the new code, `aggParams[0]` is ignored; the branch is selected purely by `len(aggParams) > 1`. Current call sites are unaffected but the type string is no longer validated.
- **`intCasts`** — New internal variable. A list of ptabler column expressions that re-cast integer columns from String (the result of `inferSchema: false` TSV loading) back to their declared Long/Int types before aggregation/dedup.
- **`pt` (ptabler)** — New import replacing `exec`, `assets`, and the `paggregateSw` software handle. Provides a DataFrame API (`workflow`, `frame`, `withColumns`, `groupBy`, `agg`, `unique`, `col`, `save`, `run`) used to implement in-process table operations.

- The old `max_by` code path had a variable-shadowing bug (`pickCols := []` re-declared inside the block, then immediately iterated) that caused it to pass an empty `pickCols` to the aggregation binary; the new implementation fixes this.
- The `aggParams[0]` aggregation-type string is now silently discarded; dispatch is by argument count only. All current callers still work correctly but the contract is no longer enforced.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all current call sites behave correctly; only the dropped aggParams[0] type-string leaves a latent gap in input validation.

The functional change is well-scoped: all three concrete call sites pass either ("first") or ("max_by", rankCol), mapping cleanly onto the new arity-based dispatch. The old max_by path had a variable-shadowing bug that caused an empty column list to be sent to the binary; the new code fixes that. The one gap is that aggParams[0] is now silently ignored, so a mistaken call such as passing only "max_by" without a ranking column silently falls through to dedup-by-first instead of failing fast.

workflow/src/tables-aggregation.lib.tengo — verify the aggParams arity contract is documented or enforced, and confirm ptabler's maxBy semantics on Long-typed columns match the previous ptransform max_by behaviour.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/tables-aggregation.lib.tengo | Migrates ensureUniqueness from a shell-invoked ptransform binary to a ptabler (pt) DataFrame workflow; adds type-aware integer casting after TSV read; aggParams[0] (aggregation type string) is silently dropped in favour of arity-based dispatch |
| .changeset/blue-shirts-kneel.md | Changeset entry marking both workflow and root packages as minor-bump for the ptabler migration — no code changes |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ensureUniqueness called\ninputTsv, params, ...aggParams] --> B[Build allCols\naxes + value columns]
    B --> C[Collect keyNames\nfrom params.axes]
    C --> D[pt.workflow\nwf.frame inputTsv as TSV\ninferSchema: false]
    D --> E{Any Long/Int\ncolumns in allCols?}
    E -- Yes --> F[withColumns: cast String to Double to round to Long/Int\nfor each integer column]
    E -- No --> G{len aggParams > 1?}
    F --> G
    G -- Yes: max_by path --> H[rankCol = aggParams 1\nmap params.columns to maxBy rankCol\ndf.groupBy keyNames .agg aggs...]
    G -- No: first path --> I[df.unique subset: keyNames\nkeep: first, maintainOrder: true]
    H --> J[result.save output.tsv]
    I --> J
    J --> K[wf.run .getFile output.tsv\nreturn deduplicated TSV]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ensureUniqueness called\ninputTsv, params, ...aggParams] --> B[Build allCols\naxes + value columns]
    B --> C[Collect keyNames\nfrom params.axes]
    C --> D[pt.workflow\nwf.frame inputTsv as TSV\ninferSchema: false]
    D --> E{Any Long/Int\ncolumns in allCols?}
    E -- Yes --> F[withColumns: cast String to Double to round to Long/Int\nfor each integer column]
    E -- No --> G{len aggParams > 1?}
    F --> G
    G -- Yes: max_by path --> H[rankCol = aggParams 1\nmap params.columns to maxBy rankCol\ndf.groupBy keyNames .agg aggs...]
    G -- No: first path --> I[df.unique subset: keyNames\nkeep: first, maintainOrder: true]
    H --> J[result.save output.tsv]
    I --> J
    J --> K[wf.run .getFile output.tsv\nreturn deduplicated TSV]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aworkflow%2Fsrc%2Ftables-aggregation.lib.tengo%3A46-56%0A**%60aggParams%5B0%5D%60%20type%20string%20silently%20ignored**%0A%0AThe%20old%20API%20used%20%60aggParams%5B0%5D%60%20as%20the%20aggregation-type%20discriminator%20%28%22max_by%22%20or%20%22first%22%29.%20The%20new%20implementation%20discards%20it%20entirely%20and%20dispatches%20only%20on%20%60len%28aggParams%29%20%3E%201%60.%20A%20call%20like%20%60ensureUniqueness%28tsv%2C%20params%2C%20%22max_by%22%29%60%20%28type%20provided%20but%20ranking%20column%20omitted%29%20now%20silently%20falls%20into%20the%20%60df.unique%28%29%60%20branch%20instead%20of%20raising%20an%20error%2C%20and%20a%20hypothetical%20future%20caller%20passing%20a%20third%20aggregation%20type%20with%20two%20arguments%20would%20silently%20be%20treated%20as%20%60max_by%60.%20Since%20all%20current%20call%20sites%20happen%20to%20map%201%3A1%20%281%20arg%20%E2%86%92%20first%2C%202%20args%20%E2%86%92%20max_by%29%2C%20there%20is%20no%20current%20regression%2C%20but%20the%20contract%20is%20no%20longer%20enforced.%0A%0A&repo=platforma-open%2Fmixcr-shm-trees&pr=123&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
workflow/src/tables-aggregation.lib.tengo:46-56
**`aggParams[0]` type string silently ignored**

The old API used `aggParams[0]` as the aggregation-type discriminator ("max_by" or "first"). The new implementation discards it entirely and dispatches only on `len(aggParams) > 1`. A call like `ensureUniqueness(tsv, params, "max_by")` (type provided but ranking column omitted) now silently falls into the `df.unique()` branch instead of raising an error, and a hypothetical future caller passing a third aggregation type with two arguments would silently be treated as `max_by`. Since all current call sites happen to map 1:1 (1 arg → first, 2 args → max_by), there is no current regression, but the contract is no longer enforced.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Migrate to ptabler"](https://github.com/platforma-open/mixcr-shm-trees/commit/23dda1138a3f34e594c52a309418a373f0de651b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43685820)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->